### PR TITLE
feat(vim): add vim 8+ colorscheme platform

### DIFF
--- a/.github/workflows/release-themes.yml
+++ b/.github/workflows/release-themes.yml
@@ -78,6 +78,12 @@ jobs:
             colors/ \
             lua/
 
+      - name: Package Vim
+        run: |
+          cd vim
+          zip -r ../warm-burnout-vim.zip \
+            colors/
+
       - name: Package Xcode
         run: |
           cd xcode
@@ -153,6 +159,7 @@ jobs:
             warm-burnout-starship.zip
             warm-burnout-zed.zip
             warm-burnout-nvim.zip
+            warm-burnout-vim.zip
             warm-burnout-xcode.zip
             warm-burnout-iterm2.zip
             warm-burnout-windows-terminal.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ warm-burnout/
     tmux.rs                   # tmux theme validation tests
     zellij.rs                 # Zellij theme validation tests
     zsh.rs                    # Zsh theme validation tests
+    nvim.rs                   # Neovim theme validation tests
+    vim.rs                    # Vim theme validation tests
     obsidian.rs               # Obsidian theme validation tests
   .github/workflows/
     validate.yml              # CI: run theme validation on push/PR
@@ -99,6 +101,12 @@ warm-burnout/
         palette.lua           # Dark + light palette tables
         highlights.lua        # All highlight group definitions
         terminal.lua          # Terminal ANSI colors (16 colors)
+  vim/                        # Vim colorscheme (Vim 8+)
+    README.md                 # Vim install instructions
+    AGENTS.md                 # Vim-specific agent rules
+    colors/
+      warm-burnout-dark.vim   # Self-contained dark variant
+      warm-burnout-light.vim  # Self-contained light variant
   xcode/                      # Xcode color theme
     README.md                 # Xcode install instructions
     AGENTS.md                 # Xcode-specific agent rules

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Inspired by materials that age well. Unlike your eyes.
 | Ghostty | Available | [`ghostty/`](ghostty/) |
 | Zed | Available | [`zed/`](zed/) |
 | Neovim | Available | [`nvim/`](nvim/) |
+| Vim | Available | [`vim/`](vim/) |
 | Xcode | Available | [`xcode/`](xcode/) |
 | iTerm2 | Available | [`iterm2/`](iterm2/) |
 | Windows Terminal | Available | [`windows-terminal/`](windows-terminal/) |

--- a/site/index.html
+++ b/site/index.html
@@ -414,6 +414,12 @@
             <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
           </a>
 
+          <a href="https://github.com/felipefdl/warm-burnout/tree/main/vim" class="retro-card rounded-md p-4 no-underline block">
+            <p class="text-sm font-bold theme-fg">Vim</p>
+            <p class="text-xs theme-fg-muted mt-1">Editor</p>
+            <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
+          </a>
+
           <a href="https://github.com/felipefdl/warm-burnout/tree/main/xcode" class="retro-card rounded-md p-4 no-underline block">
             <p class="text-sm font-bold theme-fg">Xcode</p>
             <p class="text-xs theme-fg-muted mt-1">Editor</p>

--- a/tests/vim.rs
+++ b/tests/vim.rs
@@ -1,0 +1,639 @@
+mod common;
+
+use common::{extract_hex_colors, hex_to_lower, is_valid_hex};
+
+const DARK: &str = include_str!("../vim/colors/warm-burnout-dark.vim");
+const LIGHT: &str = include_str!("../vim/colors/warm-burnout-light.vim");
+
+// -- Helpers --
+
+/// Find a highlight line whose first token (after `hi` or `highlight`) matches `group`.
+/// Matches the whole word so `Type` doesn't pick up `Typedef`.
+fn highlight_line<'a>(src: &'a str, group: &str) -> Option<&'a str> {
+  src.lines().find(|l| {
+    let t = l.trim_start();
+    let Some(t) = t.strip_prefix("highlight ").or_else(|| t.strip_prefix("hi ")) else {
+      return false;
+    };
+    t.split_whitespace().next() == Some(group)
+  })
+}
+
+/// Read a key=value attribute from a vim highlight line. Returns the value without whitespace.
+fn hl_attr<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+  for token in line.split_whitespace() {
+    if let Some(rest) = token.strip_prefix(&format!("{key}=")) {
+      return Some(rest);
+    }
+  }
+  None
+}
+
+// -- Variants declare their colorscheme name --
+
+#[test]
+fn dark_sets_colors_name() {
+  assert!(
+    DARK.contains("let g:colors_name = 'warm-burnout-dark'"),
+    "dark variant must set g:colors_name to warm-burnout-dark"
+  );
+}
+
+#[test]
+fn light_sets_colors_name() {
+  assert!(
+    LIGHT.contains("let g:colors_name = 'warm-burnout-light'"),
+    "light variant must set g:colors_name to warm-burnout-light"
+  );
+}
+
+#[test]
+fn dark_sets_background_dark() {
+  assert!(
+    DARK.contains("set background=dark"),
+    "dark variant must set background=dark"
+  );
+}
+
+#[test]
+fn light_sets_background_light() {
+  assert!(
+    LIGHT.contains("set background=light"),
+    "light variant must set background=light"
+  );
+}
+
+#[test]
+fn dark_clears_highlights() {
+  assert!(DARK.contains("hi clear"), "dark variant must clear existing highlights");
+}
+
+#[test]
+fn light_clears_highlights() {
+  assert!(
+    LIGHT.contains("hi clear"),
+    "light variant must clear existing highlights"
+  );
+}
+
+// -- All hex colors are valid --
+
+#[test]
+fn dark_hex_colors_valid() {
+  for (line, hex) in extract_hex_colors(DARK) {
+    assert!(is_valid_hex(hex), "dark line {line}: invalid hex: {hex}");
+  }
+}
+
+#[test]
+fn light_hex_colors_valid() {
+  for (line, hex) in extract_hex_colors(LIGHT) {
+    assert!(is_valid_hex(hex), "light line {line}: invalid hex: {hex}");
+  }
+}
+
+// -- No 8-digit alpha hex (Vim does not support alpha) --
+
+#[test]
+fn dark_no_alpha_hex() {
+  for (line, hex) in extract_hex_colors(DARK) {
+    let raw = hex.trim_start_matches('#');
+    assert_ne!(raw.len(), 8, "dark line {line}: 8-digit alpha hex not supported: {hex}");
+  }
+}
+
+#[test]
+fn light_no_alpha_hex() {
+  for (line, hex) in extract_hex_colors(LIGHT) {
+    let raw = hex.trim_start_matches('#');
+    assert_ne!(
+      raw.len(),
+      8,
+      "light line {line}: 8-digit alpha hex not supported: {hex}"
+    );
+  }
+}
+
+// -- Canonical backgrounds --
+
+#[test]
+fn dark_normal_background_is_canonical() {
+  let line = highlight_line(DARK, "Normal").expect("missing Normal highlight");
+  let bg = hl_attr(line, "guibg").expect("Normal missing guibg");
+  assert_eq!(hex_to_lower(bg), "#1a1510", "dark Normal background");
+}
+
+#[test]
+fn light_normal_background_is_canonical() {
+  let line = highlight_line(LIGHT, "Normal").expect("missing Normal highlight");
+  let bg = hl_attr(line, "guibg").expect("Normal missing guibg");
+  assert_eq!(hex_to_lower(bg), "#f5ede0", "light Normal background");
+}
+
+// -- Canonical foregrounds --
+
+#[test]
+fn dark_normal_foreground_is_canonical() {
+  let line = highlight_line(DARK, "Normal").expect("missing Normal highlight");
+  let fg = hl_attr(line, "guifg").expect("Normal missing guifg");
+  assert_eq!(hex_to_lower(fg), "#bfbdb6", "dark Normal foreground");
+}
+
+#[test]
+fn light_normal_foreground_is_canonical() {
+  let line = highlight_line(LIGHT, "Normal").expect("missing Normal highlight");
+  let fg = hl_attr(line, "guifg").expect("Normal missing guifg");
+  assert_eq!(hex_to_lower(fg), "#3a3630", "light Normal foreground");
+}
+
+// -- Canonical cursor --
+
+#[test]
+fn dark_cursor_is_canonical() {
+  let line = highlight_line(DARK, "Cursor").expect("missing Cursor highlight");
+  let bg = hl_attr(line, "guibg").expect("Cursor missing guibg");
+  assert_eq!(hex_to_lower(bg), "#f5c56e", "dark Cursor");
+}
+
+#[test]
+fn light_cursor_is_canonical() {
+  let line = highlight_line(LIGHT, "Cursor").expect("missing Cursor highlight");
+  let bg = hl_attr(line, "guibg").expect("Cursor missing guibg");
+  assert_eq!(hex_to_lower(bg), "#8a6600", "light Cursor");
+}
+
+// -- No pure black/white backgrounds --
+
+#[test]
+fn dark_no_pure_black_background() {
+  let line = highlight_line(DARK, "Normal").unwrap();
+  let bg = hex_to_lower(hl_attr(line, "guibg").unwrap());
+  assert_ne!(bg, "#000000", "dark background must not be pure black");
+}
+
+#[test]
+fn light_no_pure_white_background() {
+  let line = highlight_line(LIGHT, "Normal").unwrap();
+  let bg = hex_to_lower(hl_attr(line, "guibg").unwrap());
+  assert_ne!(bg, "#ffffff", "light background must not be pure white");
+}
+
+// -- Canonical syntax colors --
+
+#[test]
+fn dark_syntax_colors_match_palette() {
+  let expected = [
+    ("Keyword", "#ff8f40"),
+    ("Function", "#ffb454"),
+    ("Type", "#90aec0"),
+    ("String", "#b4bc78"),
+    ("Comment", "#b4a89c"),
+    ("Number", "#d4a8b8"),
+    ("Operator", "#f29668"),
+    ("Tag", "#dc9e92"),
+  ];
+  for (group, expected_hex) in expected {
+    let line = highlight_line(DARK, group).unwrap_or_else(|| panic!("dark missing highlight: {group}"));
+    let fg = hl_attr(line, "guifg").unwrap_or_else(|| panic!("{group} missing guifg"));
+    assert_eq!(hex_to_lower(fg), expected_hex, "dark {group} guifg");
+  }
+}
+
+#[test]
+fn light_syntax_colors_match_palette() {
+  let expected = [
+    ("Keyword", "#924800"),
+    ("Function", "#855700"),
+    ("Type", "#285464"),
+    ("String", "#4d5c1a"),
+    ("Comment", "#544c40"),
+    ("Number", "#7e4060"),
+    ("Operator", "#8f4418"),
+    ("Tag", "#8e4632"),
+  ];
+  for (group, expected_hex) in expected {
+    let line = highlight_line(LIGHT, group).unwrap_or_else(|| panic!("light missing highlight: {group}"));
+    let fg = hl_attr(line, "guifg").unwrap_or_else(|| panic!("{group} missing guifg"));
+    assert_eq!(hex_to_lower(fg), expected_hex, "light {group} guifg");
+  }
+}
+
+// -- Diagnostic colors --
+
+#[test]
+fn dark_diagnostic_colors() {
+  let cases = [
+    ("DiagnosticError", "#f49090"),
+    ("DiagnosticWarn", "#b8522e"),
+    ("DiagnosticInfo", "#90aec0"),
+    ("DiagnosticHint", "#b4a89c"),
+  ];
+  for (group, hex) in cases {
+    let line = highlight_line(DARK, group).unwrap_or_else(|| panic!("missing {group}"));
+    let fg = hl_attr(line, "guifg").unwrap();
+    assert_eq!(hex_to_lower(fg), hex, "dark {group}");
+  }
+}
+
+#[test]
+fn light_diagnostic_colors() {
+  let cases = [
+    ("DiagnosticError", "#b03434"),
+    ("DiagnosticWarn", "#b8522e"),
+    ("DiagnosticInfo", "#285464"),
+    ("DiagnosticHint", "#544c40"),
+  ];
+  for (group, hex) in cases {
+    let line = highlight_line(LIGHT, group).unwrap_or_else(|| panic!("missing {group}"));
+    let fg = hl_attr(line, "guifg").unwrap();
+    assert_eq!(hex_to_lower(fg), hex, "light {group}");
+  }
+}
+
+// -- Git colors --
+
+#[test]
+fn dark_git_colors() {
+  let cases = [
+    ("GitGutterAdd", "#70bf56"),
+    ("GitGutterChange", "#73b8ff"),
+    ("GitGutterDelete", "#f26d78"),
+  ];
+  for (group, hex) in cases {
+    let line = highlight_line(DARK, group).unwrap_or_else(|| panic!("missing {group}"));
+    let fg = hl_attr(line, "guifg").unwrap();
+    assert_eq!(hex_to_lower(fg), hex, "dark {group}");
+  }
+}
+
+#[test]
+fn light_git_colors() {
+  let cases = [
+    ("GitGutterAdd", "#226414"),
+    ("GitGutterChange", "#2868a0"),
+    ("GitGutterDelete", "#c43040"),
+  ];
+  for (group, hex) in cases {
+    let line = highlight_line(LIGHT, group).unwrap_or_else(|| panic!("missing {group}"));
+    let fg = hl_attr(line, "guifg").unwrap();
+    assert_eq!(hex_to_lower(fg), hex, "light {group}");
+  }
+}
+
+// -- Required highlight groups --
+
+const REQUIRED_EDITOR_UI: &[&str] = &[
+  "Normal",
+  "NormalFloat",
+  "Visual",
+  "CursorLine",
+  "CursorLineNr",
+  "LineNr",
+  "SignColumn",
+  "Pmenu",
+  "PmenuSel",
+  "Search",
+  "IncSearch",
+  "StatusLine",
+  "StatusLineNC",
+  "TabLine",
+  "TabLineSel",
+  "TabLineFill",
+  "FloatBorder",
+  "WinSeparator",
+  "MatchParen",
+  "Directory",
+];
+
+const REQUIRED_SYNTAX: &[&str] = &[
+  "Comment",
+  "Constant",
+  "String",
+  "Number",
+  "Boolean",
+  "Function",
+  "Statement",
+  "Keyword",
+  "Operator",
+  "Type",
+  "PreProc",
+  "Special",
+  "Identifier",
+  "Delimiter",
+  "Error",
+  "Todo",
+];
+
+const REQUIRED_DIAGNOSTIC: &[&str] = &[
+  "DiagnosticError",
+  "DiagnosticWarn",
+  "DiagnosticInfo",
+  "DiagnosticHint",
+  "DiagnosticSignError",
+  "DiagnosticUnderlineError",
+  "DiagnosticVirtualTextError",
+];
+
+const REQUIRED_GIT: &[&str] = &["GitGutterAdd", "GitGutterChange", "GitGutterDelete"];
+
+#[test]
+fn dark_has_editor_ui_groups() {
+  for group in REQUIRED_EDITOR_UI {
+    assert!(
+      highlight_line(DARK, group).is_some(),
+      "dark missing editor UI group: {group}"
+    );
+  }
+}
+
+#[test]
+fn light_has_editor_ui_groups() {
+  for group in REQUIRED_EDITOR_UI {
+    assert!(
+      highlight_line(LIGHT, group).is_some(),
+      "light missing editor UI group: {group}"
+    );
+  }
+}
+
+#[test]
+fn dark_has_syntax_groups() {
+  for group in REQUIRED_SYNTAX {
+    assert!(
+      highlight_line(DARK, group).is_some(),
+      "dark missing syntax group: {group}"
+    );
+  }
+}
+
+#[test]
+fn light_has_syntax_groups() {
+  for group in REQUIRED_SYNTAX {
+    assert!(
+      highlight_line(LIGHT, group).is_some(),
+      "light missing syntax group: {group}"
+    );
+  }
+}
+
+#[test]
+fn dark_has_diagnostic_groups() {
+  for group in REQUIRED_DIAGNOSTIC {
+    assert!(
+      highlight_line(DARK, group).is_some(),
+      "dark missing diagnostic group: {group}"
+    );
+  }
+}
+
+#[test]
+fn light_has_diagnostic_groups() {
+  for group in REQUIRED_DIAGNOSTIC {
+    assert!(
+      highlight_line(LIGHT, group).is_some(),
+      "light missing diagnostic group: {group}"
+    );
+  }
+}
+
+#[test]
+fn dark_has_git_groups() {
+  for group in REQUIRED_GIT {
+    assert!(highlight_line(DARK, group).is_some(), "dark missing git group: {group}");
+  }
+}
+
+#[test]
+fn light_has_git_groups() {
+  for group in REQUIRED_GIT {
+    assert!(
+      highlight_line(LIGHT, group).is_some(),
+      "light missing git group: {group}"
+    );
+  }
+}
+
+// -- Font style system: bold keywords, italic types, italic comments --
+
+fn assert_style(src: &str, group: &str, style: &str, variant: &str) {
+  let line = highlight_line(src, group).unwrap_or_else(|| panic!("{variant} missing {group}"));
+  let gui = hl_attr(line, "gui").unwrap_or_else(|| panic!("{variant} {group} missing gui="));
+  let cterm = hl_attr(line, "cterm").unwrap_or_else(|| panic!("{variant} {group} missing cterm="));
+  assert!(
+    gui.split(',').any(|s| s == style),
+    "{variant} {group} gui= should include {style}, got: {gui}"
+  );
+  assert!(
+    cterm.split(',').any(|s| s == style),
+    "{variant} {group} cterm= should include {style}, got: {cterm}"
+  );
+}
+
+#[test]
+fn dark_keywords_are_bold() {
+  assert_style(DARK, "Keyword", "bold", "dark");
+  assert_style(DARK, "Statement", "bold", "dark");
+  assert_style(DARK, "Conditional", "bold", "dark");
+}
+
+#[test]
+fn light_keywords_are_bold() {
+  assert_style(LIGHT, "Keyword", "bold", "light");
+  assert_style(LIGHT, "Statement", "bold", "light");
+  assert_style(LIGHT, "Conditional", "bold", "light");
+}
+
+#[test]
+fn dark_tags_are_bold() {
+  assert_style(DARK, "Tag", "bold", "dark");
+}
+
+#[test]
+fn light_tags_are_bold() {
+  assert_style(LIGHT, "Tag", "bold", "light");
+}
+
+#[test]
+fn dark_comments_are_italic() {
+  assert_style(DARK, "Comment", "italic", "dark");
+}
+
+#[test]
+fn light_comments_are_italic() {
+  assert_style(LIGHT, "Comment", "italic", "light");
+}
+
+#[test]
+fn dark_types_are_italic() {
+  assert_style(DARK, "Type", "italic", "dark");
+  assert_style(DARK, "Typedef", "italic", "dark");
+  assert_style(DARK, "Structure", "italic", "dark");
+}
+
+#[test]
+fn light_types_are_italic() {
+  assert_style(LIGHT, "Type", "italic", "light");
+  assert_style(LIGHT, "Typedef", "italic", "light");
+  assert_style(LIGHT, "Structure", "italic", "light");
+}
+
+// -- Diagnostics use undercurl --
+
+#[test]
+fn dark_diagnostic_underlines_use_undercurl() {
+  for group in [
+    "DiagnosticUnderlineError",
+    "DiagnosticUnderlineWarn",
+    "DiagnosticUnderlineInfo",
+    "DiagnosticUnderlineHint",
+  ] {
+    let line = highlight_line(DARK, group).unwrap_or_else(|| panic!("missing {group}"));
+    let gui = hl_attr(line, "gui").unwrap();
+    assert!(gui.contains("undercurl"), "dark {group} should use undercurl");
+  }
+}
+
+#[test]
+fn light_diagnostic_underlines_use_undercurl() {
+  for group in [
+    "DiagnosticUnderlineError",
+    "DiagnosticUnderlineWarn",
+    "DiagnosticUnderlineInfo",
+    "DiagnosticUnderlineHint",
+  ] {
+    let line = highlight_line(LIGHT, group).unwrap_or_else(|| panic!("missing {group}"));
+    let gui = hl_attr(line, "gui").unwrap();
+    assert!(gui.contains("undercurl"), "light {group} should use undercurl");
+  }
+}
+
+// -- Terminal ANSI: both variants declare 16 colors --
+
+fn extract_terminal_ansi(src: &str) -> Vec<String> {
+  let start = src
+    .find("g:terminal_ansi_colors")
+    .expect("missing g:terminal_ansi_colors");
+  let block = &src[start..];
+  let close = block.find(']').expect("missing closing bracket");
+  let block = &block[..close];
+
+  block
+    .split('\'')
+    .filter_map(|s| {
+      let s = s.trim();
+      if s.starts_with('#') && (s.len() == 7 || s.len() == 4) {
+        Some(hex_to_lower(s))
+      } else {
+        None
+      }
+    })
+    .collect()
+}
+
+#[test]
+fn dark_terminal_has_16_colors() {
+  let colors = extract_terminal_ansi(DARK);
+  assert_eq!(colors.len(), 16, "dark terminal_ansi_colors must have 16 entries");
+}
+
+#[test]
+fn light_terminal_has_16_colors() {
+  let colors = extract_terminal_ansi(LIGHT);
+  assert_eq!(colors.len(), 16, "light terminal_ansi_colors must have 16 entries");
+}
+
+// -- Terminal ANSI matches Ghostty/VS Code --
+
+#[test]
+fn dark_terminal_ansi_matches_ghostty() {
+  let ghostty = include_str!("../ghostty/warm-burnout-dark");
+  let vim_colors = extract_terminal_ansi(DARK);
+
+  let ghostty_colors: Vec<String> = ghostty
+    .lines()
+    .filter(|l| l.starts_with("palette"))
+    .filter_map(|l| {
+      l.split_once('=')
+        .and_then(|(_, v)| v.trim().split_once('='))
+        .map(|(_, hex)| hex_to_lower(hex))
+    })
+    .collect();
+
+  for (i, expected) in ghostty_colors.iter().enumerate() {
+    assert_eq!(
+      &vim_colors[i], expected,
+      "dark terminal_color_{i}: vim={} ghostty={expected}",
+      vim_colors[i]
+    );
+  }
+}
+
+#[test]
+fn light_terminal_ansi_matches_vscode() {
+  let vscode: serde_json::Value =
+    serde_json::from_str(include_str!("../vscode/themes/warm-burnout-light.json")).unwrap();
+  let vim_colors = extract_terminal_ansi(LIGHT);
+
+  let ansi_keys = [
+    "ansiBlack",
+    "ansiRed",
+    "ansiGreen",
+    "ansiYellow",
+    "ansiBlue",
+    "ansiMagenta",
+    "ansiCyan",
+    "ansiWhite",
+    "ansiBrightBlack",
+    "ansiBrightRed",
+    "ansiBrightGreen",
+    "ansiBrightYellow",
+    "ansiBrightBlue",
+    "ansiBrightMagenta",
+    "ansiBrightCyan",
+    "ansiBrightWhite",
+  ];
+
+  for (i, ansi_key) in ansi_keys.iter().enumerate() {
+    let vscode_key = format!("terminal.{ansi_key}");
+    let vscode_hex = hex_to_lower(vscode["colors"][&vscode_key].as_str().unwrap());
+    assert_eq!(
+      vim_colors[i], vscode_hex,
+      "light terminal_color_{i}: vim={} vscode={vscode_hex}",
+      vim_colors[i]
+    );
+  }
+}
+
+// -- Every highlight sets both GUI and cterm attributes (with allowlisted exceptions) --
+//
+// Style-only groups like Underlined or plain gui=undercurl lines legitimately omit
+// guifg/ctermfg. This test only checks foreground color groups.
+
+fn color_highlight_lines(src: &str) -> impl Iterator<Item = &str> {
+  src.lines().filter(|l| {
+    let t = l.trim_start();
+    (t.starts_with("hi ") || t.starts_with("highlight ")) && t.contains("guifg=#") && !t.contains("guifg=NONE")
+  })
+}
+
+#[test]
+fn dark_color_highlights_have_cterm_equivalents() {
+  for line in color_highlight_lines(DARK) {
+    assert!(
+      line.contains("ctermfg="),
+      "dark highlight missing ctermfg: {}",
+      line.trim()
+    );
+  }
+}
+
+#[test]
+fn light_color_highlights_have_cterm_equivalents() {
+  for line in color_highlight_lines(LIGHT) {
+    assert!(
+      line.contains("ctermfg="),
+      "light highlight missing ctermfg: {}",
+      line.trim()
+    );
+  }
+}

--- a/vim/AGENTS.md
+++ b/vim/AGENTS.md
@@ -1,0 +1,71 @@
+# Vim -- Agent Instructions
+
+## Platform Reference
+
+See the root [`AGENTS.md`](../AGENTS.md) for the canonical palette, design principles, and brand rules. Do not duplicate palette tables here.
+
+## Scope
+
+This platform is for classic Vim (Vim 8+). Neovim users should use [`nvim/`](../nvim/) instead, which supports Treesitter, LSP semantic tokens, and Lua-based plugin integrations.
+
+## Vim Colorscheme Format
+
+- Vim colorschemes are single `.vim` files loaded from `colors/` on the runtimepath.
+- Each variant is self-contained: it resets highlights, sets `g:colors_name`, and issues `highlight` commands.
+- Both `guifg`/`guibg` (for `termguicolors`) and `ctermfg`/`ctermbg` (for 256-color terminals) are set on every group.
+- Font style attributes (`bold`, `italic`, `underline`, `undercurl`) are set via `gui=` and `cterm=`.
+- Terminal ANSI colors are set via `g:terminal_ansi_colors` (a 16-element list).
+
+## Structure
+
+```
+vim/
+  colors/
+    warm-burnout-dark.vim     -- Self-contained dark variant
+    warm-burnout-light.vim    -- Self-contained light variant
+  README.md                   -- Install instructions
+  AGENTS.md                   -- This file
+```
+
+## Dual-Color Convention
+
+Every `highlight` command sets both:
+
+- `guifg=#rrggbb` for truecolor terminals (`set termguicolors`)
+- `ctermfg=N` (0-255) for 256-color terminals
+
+The 256-color indices are perceptual approximations of the canonical hex values. They lose some fidelity (256 colors cannot reproduce the exact WCAG-tuned ratios), but they keep the overall warm palette coherent.
+
+## Font Style System
+
+The three-tier non-color discrimination channel from root `AGENTS.md` is preserved:
+
+- `gui=bold cterm=bold` for keywords, storage classes, HTML tags
+- `gui=italic cterm=italic` for types, comments, CSS properties, decorators
+- No style (normal) for everything else
+
+This must apply to both the GUI and cterm variants.
+
+## Color Rules
+
+1. Use exact hex values from the canonical palette for all `guifg`/`guibg`. No approximations.
+2. 256-color (`cterm*`) indices are nearest-neighbor approximations. Changing them is acceptable as long as the perceptual role is preserved.
+3. Terminal ANSI colors (`g:terminal_ansi_colors`) match the Ghostty/VS Code terminal palette exactly.
+4. No alpha transparency: Vim does not support it. Use pre-blended opaque equivalents.
+
+## Adding Plugin Support
+
+1. Add `highlight` commands for the plugin's groups in both variant files.
+2. Use the same semantic color (keyword = `#ff8f40` dark / `#924800` light, etc.) as other platforms.
+3. Always set both GUI and cterm attributes.
+4. Keep plugin sections ordered by plugin name for searchability.
+
+## Testing
+
+Run `cargo test --test vim` to validate the colorscheme files. Tests check for:
+
+- Canonical palette colors present in both variants
+- Required highlight groups (editor UI, syntax, diagnostics, git)
+- Font style system preserved (keywords bold, types italic, comments italic)
+- Terminal ANSI arrays have 16 entries
+- `g:colors_name` set correctly per variant

--- a/vim/README.md
+++ b/vim/README.md
@@ -1,0 +1,83 @@
+# Warm Burnout for Vim
+
+Your retinas asked nicely. A classic Vim colorscheme -- no Lua, no Treesitter, no runtime dependencies. Just 200+ highlight groups of clinically warm, emotionally cold syntax highlighting.
+
+Requires Vim 8.0 or newer. For Neovim, use the [`nvim/`](../nvim/) platform instead.
+
+## Installation
+
+### vim-plug
+
+```vim
+Plug 'felipefdl/warm-burnout', { 'rtp': 'vim' }
+```
+
+Then in your `vimrc`:
+
+```vim
+set termguicolors
+colorscheme warm-burnout-dark
+```
+
+### Vim 8 packages (native)
+
+```sh
+mkdir -p ~/.vim/pack/themes/start
+git clone https://github.com/felipefdl/warm-burnout ~/.vim/pack/themes/start/warm-burnout
+```
+
+Then symlink or copy the `vim/colors/` directory into your runtimepath:
+
+```sh
+mkdir -p ~/.vim/colors
+cp ~/.vim/pack/themes/start/warm-burnout/vim/colors/*.vim ~/.vim/colors/
+```
+
+### Manual
+
+Drop `warm-burnout-dark.vim` and `warm-burnout-light.vim` into `~/.vim/colors/`.
+
+## Usage
+
+```vim
+set termguicolors
+colorscheme warm-burnout-dark
+" or
+colorscheme warm-burnout-light
+```
+
+`termguicolors` is strongly recommended. Without it, Vim falls back to the nearest 256-color approximation, which loses the carefully tuned contrast ratios.
+
+## Variants
+
+- `warm-burnout-dark`: AAA contrast, warm brown-black background (`#1a1510`)
+- `warm-burnout-light`: AA contrast, sepia cream background (`#F5EDE0`)
+
+## Supported Plugins
+
+- ALE
+- coc.nvim
+- vim-gitgutter
+- vim-signify
+- NERDTree
+- netrw
+
+## The Palette
+
+Inspired by materials that age well. Unlike your eyes.
+
+| Material | Dark | Light | Used for |
+|----------|------|-------|----------|
+| Amber | `#ffb454` | `#855700` | Functions |
+| Burnt orange | `#ff8f40` | `#924800` | Keywords |
+| Terra cotta | `#dc9e92` | `#8e4632` | HTML tags |
+| Dried sage | `#b4bc78` | `#4d5c1a` | Strings |
+| Verdigris | `#96b898` | `#286a48` | Regex, escapes |
+| Dusty mauve | `#d4a8b8` | `#7e4060` | Numbers, constants |
+| Coral | `#ec9878` | `#883850` | Member variables |
+| Warm stone | `#b4a89c` | `#544c40` | Comments |
+| Aged brass | `#deb074` | `#74501c` | CSS properties |
+| Steel patina | `#90aec0` | `#285464` | Types, classes |
+| Gold | `#e6c08a` | `#7a5a1c` | Decorators |
+
+The burnout is spreading.

--- a/vim/colors/warm-burnout-dark.vim
+++ b/vim/colors/warm-burnout-dark.vim
@@ -1,0 +1,264 @@
+" Warm Burnout Dark -- clinically warm, emotionally cold
+" Background: #1a1510. All tokens >= 7.0:1 contrast (WCAG AAA).
+
+hi clear
+if exists('syntax_on')
+  syntax reset
+endif
+
+set background=dark
+let g:colors_name = 'warm-burnout-dark'
+
+" -- Terminal ANSI colors (16) --
+let g:terminal_ansi_colors = [
+      \ '#23211b', '#f06b73', '#70bf56', '#fdb04c',
+      \ '#4fbfff', '#d0a1ff', '#93e2c8', '#c7c7c7',
+      \ '#686868', '#f07178', '#aad94c', '#ffb454',
+      \ '#59c2ff', '#d2a6ff', '#95e6cb', '#ffffff',
+      \ ]
+
+" -- Editor UI --
+hi Normal           guifg=#bfbdb6 guibg=#1a1510 ctermfg=250 ctermbg=234
+hi NormalNC         guifg=#bfbdb6 guibg=#1a1510 ctermfg=250 ctermbg=234
+hi NormalFloat      guifg=#bfbdb6 guibg=#1f1d17 ctermfg=250 ctermbg=235
+hi FloatBorder      guifg=#2a2820 guibg=#1f1d17 ctermfg=236 ctermbg=235
+hi FloatTitle       guifg=#bfbdb6 guibg=#1f1d17 gui=bold   ctermfg=250 ctermbg=235 cterm=bold
+hi EndOfBuffer      guifg=#1a1510 guibg=#1a1510 ctermfg=234 ctermbg=234
+
+hi Cursor           guifg=#1a1510 guibg=#f5c56e ctermfg=234 ctermbg=221
+hi lCursor          guifg=#1a1510 guibg=#f5c56e ctermfg=234 ctermbg=221
+hi CursorIM         guifg=#1a1510 guibg=#f5c56e ctermfg=234 ctermbg=221
+hi CursorLine                     guibg=#222018             ctermbg=235 cterm=NONE
+hi CursorColumn                   guibg=#222018             ctermbg=235
+hi CursorLineNr     guifg=#a59f96 guibg=NONE    ctermfg=246 ctermbg=NONE
+hi LineNr           guifg=#6b6860 guibg=NONE    ctermfg=242 ctermbg=NONE
+hi SignColumn       guifg=#6b6860 guibg=#1a1510 ctermfg=242 ctermbg=234
+hi ColorColumn                    guibg=#222018             ctermbg=235
+hi Folded           guifg=#b4a89c guibg=#1f1d17 gui=italic  ctermfg=144 ctermbg=235 cterm=italic
+hi FoldColumn       guifg=#6b6860 guibg=NONE    ctermfg=242 ctermbg=NONE
+
+hi VertSplit        guifg=#2a2820 guibg=NONE    ctermfg=236 ctermbg=NONE
+hi WinSeparator     guifg=#2a2820 guibg=NONE    ctermfg=236 ctermbg=NONE
+hi StatusLine       guifg=#ada69c guibg=#14120f             ctermfg=248 ctermbg=233 cterm=NONE
+hi StatusLineNC     guifg=#6b6860 guibg=#14120f             ctermfg=242 ctermbg=233 cterm=NONE
+hi TabLine          guifg=#ada69c guibg=#14120f             ctermfg=248 ctermbg=233 cterm=NONE
+hi TabLineSel       guifg=#bfbdb6 guibg=#1a1510 gui=bold   ctermfg=250 ctermbg=234 cterm=bold
+hi TabLineFill      guifg=#ada69c guibg=#14120f             ctermfg=248 ctermbg=233
+
+hi Visual                         guibg=#2e3a41             ctermbg=238
+hi VisualNOS                      guibg=#2e3a41             ctermbg=238
+
+hi Pmenu            guifg=#bfbdb6 guibg=#1f1d17             ctermfg=250 ctermbg=235
+hi PmenuSel         guifg=#bfbdb6 guibg=#2e3a41 gui=bold   ctermfg=250 ctermbg=238 cterm=bold
+hi PmenuSbar                      guibg=#1f1d17             ctermbg=235
+hi PmenuThumb                     guibg=#6b6860             ctermbg=242
+hi WildMenu                       guibg=#2e3a41             ctermbg=238
+
+hi Search           guifg=#bfbdb6 guibg=#4c4126             ctermfg=250 ctermbg=94
+hi IncSearch        guifg=#1a1510 guibg=#f5c56e             ctermfg=234 ctermbg=221
+hi CurSearch        guifg=#1a1510 guibg=#f5c56e             ctermfg=234 ctermbg=221
+hi Substitute       guifg=#1a1510 guibg=#f49090             ctermfg=234 ctermbg=210
+hi MatchParen       guifg=#b8522e guibg=NONE    gui=bold   ctermfg=173 ctermbg=NONE cterm=bold
+hi QuickFixLine                   guibg=#2e3a41             ctermbg=238
+
+hi SpecialKey       guifg=#6b6860             ctermfg=242
+hi NonText          guifg=#6b6860             ctermfg=242
+hi Whitespace       guifg=#6b6860             ctermfg=242
+hi Conceal          guifg=#ada69c             ctermfg=248
+
+hi Directory        guifg=#ffb454             ctermfg=214
+hi Title            guifg=#ffb454 gui=bold    ctermfg=214 cterm=bold
+hi ErrorMsg         guifg=#f49090             ctermfg=210
+hi WarningMsg       guifg=#b8522e             ctermfg=173
+hi MoreMsg          guifg=#90aec0             ctermfg=109
+hi Question         guifg=#90aec0             ctermfg=109
+hi ModeMsg          guifg=#bfbdb6 gui=bold    ctermfg=250 cterm=bold
+
+" -- Spell --
+hi SpellBad   guisp=#f49090 gui=undercurl cterm=undercurl
+hi SpellCap   guisp=#b8522e gui=undercurl cterm=undercurl
+hi SpellLocal guisp=#90aec0 gui=undercurl cterm=undercurl
+hi SpellRare  guisp=#b4a89c gui=undercurl cterm=undercurl
+
+" -- Diff --
+hi DiffAdd                   guibg=#1e2a1c ctermbg=22
+hi DiffChange                guibg=#1a242e ctermbg=23
+hi DiffDelete                guibg=#2e1a1c ctermbg=52
+hi DiffText                  guibg=#2c3e52 ctermbg=24
+
+" -- Syntax groups --
+hi Comment        guifg=#b4a89c gui=italic              ctermfg=144 cterm=italic
+hi Constant       guifg=#d4a8b8                         ctermfg=181
+hi String         guifg=#b4bc78                         ctermfg=143
+hi Character      guifg=#b4bc78                         ctermfg=143
+hi Number         guifg=#d4a8b8                         ctermfg=181
+hi Boolean        guifg=#d4a8b8                         ctermfg=181
+hi Float          guifg=#d4a8b8                         ctermfg=181
+hi Identifier     guifg=#bfbdb6                         ctermfg=250 cterm=NONE
+hi Function       guifg=#ffb454                         ctermfg=214
+hi Statement      guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi Conditional    guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi Repeat         guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi Label          guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi Operator       guifg=#f29668                         ctermfg=209
+hi Keyword        guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi Exception      guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi PreProc        guifg=#ff8f40                         ctermfg=208
+hi Include        guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi Define         guifg=#ff8f40                         ctermfg=208
+hi Macro          guifg=#e6c08a                         ctermfg=180
+hi PreCondit      guifg=#ff8f40                         ctermfg=208
+hi Type           guifg=#90aec0 gui=italic              ctermfg=109 cterm=italic
+hi StorageClass   guifg=#ff8f40 gui=bold                ctermfg=208 cterm=bold
+hi Structure      guifg=#90aec0 gui=italic              ctermfg=109 cterm=italic
+hi Typedef        guifg=#90aec0 gui=italic              ctermfg=109 cterm=italic
+hi Special        guifg=#f29668                         ctermfg=209
+hi SpecialChar    guifg=#96b898                         ctermfg=108
+hi Tag            guifg=#dc9e92 gui=bold                ctermfg=174 cterm=bold
+hi Delimiter      guifg=#bfbdb6                         ctermfg=250
+hi SpecialComment guifg=#b4a89c gui=italic              ctermfg=144 cterm=italic
+hi Debug          guifg=#b8522e                         ctermfg=173
+hi Underlined                   gui=underline          cterm=underline
+hi Ignore         guifg=#ada69c                         ctermfg=248
+hi Error          guifg=#f49090                         ctermfg=210
+hi Todo           guifg=#f5c56e gui=bold                ctermfg=221 cterm=bold
+hi Added          guifg=#70bf56                         ctermfg=71
+hi Changed        guifg=#73b8ff                         ctermfg=75
+hi Removed        guifg=#f26d78                         ctermfg=203
+
+" -- LSP / Diagnostics (Vim 9 / ALE / coc.nvim / vim-lsp) --
+hi DiagnosticError      guifg=#f49090 ctermfg=210
+hi DiagnosticWarn       guifg=#b8522e ctermfg=173
+hi DiagnosticInfo       guifg=#90aec0 ctermfg=109
+hi DiagnosticHint       guifg=#b4a89c ctermfg=144
+hi DiagnosticOk         guifg=#70bf56 ctermfg=71
+hi DiagnosticSignError  guifg=#f49090 ctermfg=210
+hi DiagnosticSignWarn   guifg=#b8522e ctermfg=173
+hi DiagnosticSignInfo   guifg=#90aec0 ctermfg=109
+hi DiagnosticSignHint   guifg=#b4a89c ctermfg=144
+hi DiagnosticUnderlineError guisp=#f49090 gui=undercurl cterm=undercurl
+hi DiagnosticUnderlineWarn  guisp=#b8522e gui=undercurl cterm=undercurl
+hi DiagnosticUnderlineInfo  guisp=#90aec0 gui=undercurl cterm=undercurl
+hi DiagnosticUnderlineHint  guisp=#b4a89c gui=undercurl cterm=undercurl
+hi DiagnosticVirtualTextError guifg=#f49090 ctermfg=210
+hi DiagnosticVirtualTextWarn  guifg=#b8522e ctermfg=173
+hi DiagnosticVirtualTextInfo  guifg=#90aec0 ctermfg=109
+hi DiagnosticVirtualTextHint  guifg=#b4a89c ctermfg=144
+
+hi ALEErrorSign        guifg=#f49090 ctermfg=210
+hi ALEWarningSign      guifg=#b8522e ctermfg=173
+hi ALEInfoSign         guifg=#90aec0 ctermfg=109
+hi ALEError            guisp=#f49090 gui=undercurl cterm=undercurl
+hi ALEWarning          guisp=#b8522e gui=undercurl cterm=undercurl
+
+hi CocErrorSign   guifg=#f49090 ctermfg=210
+hi CocWarningSign guifg=#b8522e ctermfg=173
+hi CocInfoSign    guifg=#90aec0 ctermfg=109
+hi CocHintSign    guifg=#b4a89c ctermfg=144
+hi CocErrorFloat  guifg=#f49090 ctermfg=210
+hi CocErrorHighlight   guisp=#f49090 gui=undercurl cterm=undercurl
+hi CocWarningHighlight guisp=#b8522e gui=undercurl cterm=undercurl
+
+" -- Git (vim-gitgutter / vim-signify) --
+hi GitGutterAdd    guifg=#70bf56 ctermfg=71
+hi GitGutterChange guifg=#73b8ff ctermfg=75
+hi GitGutterDelete guifg=#f26d78 ctermfg=203
+hi SignifySignAdd    guifg=#70bf56 ctermfg=71
+hi SignifySignChange guifg=#73b8ff ctermfg=75
+hi SignifySignDelete guifg=#f26d78 ctermfg=203
+hi diffAdded   guifg=#70bf56 ctermfg=71
+hi diffRemoved guifg=#f26d78 ctermfg=203
+hi diffChanged guifg=#73b8ff ctermfg=75
+
+" -- HTML / XML --
+hi htmlTag        guifg=#dc9e92 gui=bold ctermfg=174 cterm=bold
+hi htmlEndTag     guifg=#dc9e92 gui=bold ctermfg=174 cterm=bold
+hi htmlTagName    guifg=#dc9e92 gui=bold ctermfg=174 cterm=bold
+hi htmlArg        guifg=#ffb454          ctermfg=214
+hi htmlTitle      guifg=#bfbdb6 gui=bold ctermfg=250 cterm=bold
+hi htmlH1         guifg=#bfbdb6 gui=bold ctermfg=250 cterm=bold
+hi xmlTag         guifg=#dc9e92 gui=bold ctermfg=174 cterm=bold
+hi xmlTagName     guifg=#dc9e92 gui=bold ctermfg=174 cterm=bold
+hi xmlEndTag      guifg=#dc9e92 gui=bold ctermfg=174 cterm=bold
+
+" -- CSS --
+hi cssClassName    guifg=#e6c08a gui=italic ctermfg=180 cterm=italic
+hi cssIdentifier   guifg=#e6c08a gui=italic ctermfg=180 cterm=italic
+hi cssProp         guifg=#deb074 gui=italic ctermfg=179 cterm=italic
+hi cssAttr         guifg=#b4bc78            ctermfg=143
+hi cssAttrRegion   guifg=#b4bc78            ctermfg=143
+hi cssBraces       guifg=#bfbdb6            ctermfg=250
+hi cssPseudoClass  guifg=#ec9878            ctermfg=216
+hi cssPseudoClassId guifg=#ec9878           ctermfg=216
+hi cssValueLength  guifg=#d4a8b8            ctermfg=181
+hi cssValueNumber  guifg=#d4a8b8            ctermfg=181
+hi cssFunctionName guifg=#ffb454            ctermfg=214
+hi cssColor        guifg=#d4a8b8            ctermfg=181
+
+" -- JavaScript / TypeScript --
+hi jsFunction         guifg=#ff8f40 gui=bold  ctermfg=208 cterm=bold
+hi jsFuncCall         guifg=#ffb454           ctermfg=214
+hi jsClassDefinition  guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi jsGlobalObjects    guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi jsThis             guifg=#dc9e92 gui=italic ctermfg=174 cterm=italic
+hi jsObjectKey        guifg=#deb074 gui=italic ctermfg=179 cterm=italic
+hi typescriptKeyword     guifg=#ff8f40 gui=bold ctermfg=208 cterm=bold
+hi typescriptClassName   guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi typescriptFuncKeyword guifg=#ff8f40 gui=bold ctermfg=208 cterm=bold
+hi typescriptMember      guifg=#ec9878          ctermfg=216
+
+" -- Python --
+hi pythonBuiltin     guifg=#ec9878           ctermfg=216
+hi pythonFunction    guifg=#ffb454           ctermfg=214
+hi pythonDecorator   guifg=#e6c08a gui=italic ctermfg=180 cterm=italic
+hi pythonDecoratorName guifg=#e6c08a gui=italic ctermfg=180 cterm=italic
+hi pythonStatement   guifg=#ff8f40 gui=bold  ctermfg=208 cterm=bold
+hi pythonClass       guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi pythonSelf        guifg=#dc9e92 gui=italic ctermfg=174 cterm=italic
+
+" -- Rust --
+hi rustKeyword         guifg=#ff8f40 gui=bold ctermfg=208 cterm=bold
+hi rustType            guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi rustTrait           guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi rustMacro           guifg=#e6c08a          ctermfg=180
+hi rustAttribute       guifg=#e6c08a gui=italic ctermfg=180 cterm=italic
+hi rustLifetime        guifg=#dc9e92 gui=italic ctermfg=174 cterm=italic
+hi rustFuncCall        guifg=#ffb454          ctermfg=214
+hi rustFuncName        guifg=#ffb454          ctermfg=214
+hi rustEnumVariant     guifg=#d4a8b8          ctermfg=181
+
+" -- Markdown --
+hi markdownH1        guifg=#ff8f40 gui=bold ctermfg=208 cterm=bold
+hi markdownH2        guifg=#ffb454 gui=bold ctermfg=214 cterm=bold
+hi markdownH3        guifg=#e6c08a gui=bold ctermfg=180 cterm=bold
+hi markdownH4        guifg=#b4bc78 gui=bold ctermfg=143 cterm=bold
+hi markdownH5        guifg=#90aec0 gui=bold ctermfg=109 cterm=bold
+hi markdownH6        guifg=#dc9e92 gui=bold ctermfg=174 cterm=bold
+hi markdownCode      guifg=#b4bc78          ctermfg=143
+hi markdownCodeBlock guifg=#b4bc78          ctermfg=143
+hi markdownLinkText  guifg=#dc9e92 gui=underline ctermfg=174 cterm=underline
+hi markdownUrl       guifg=#90aec0 gui=underline ctermfg=109 cterm=underline
+hi markdownBold      guifg=#bfbdb6 gui=bold ctermfg=250 cterm=bold
+hi markdownItalic    guifg=#ec9878 gui=italic ctermfg=216 cterm=italic
+hi markdownListMarker guifg=#ffb454         ctermfg=214
+
+" -- Vim --
+hi vimCommand    guifg=#ff8f40 gui=bold ctermfg=208 cterm=bold
+hi vimFunction   guifg=#ffb454          ctermfg=214
+hi vimFuncName   guifg=#ffb454          ctermfg=214
+hi vimGroup      guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi vimHiGroup    guifg=#90aec0 gui=italic ctermfg=109 cterm=italic
+hi vimOption     guifg=#deb074 gui=italic ctermfg=179 cterm=italic
+hi vimVar        guifg=#d4a8b8          ctermfg=181
+hi vimNotation   guifg=#96b898          ctermfg=108
+
+" -- NERDTree / netrw --
+hi NERDTreeDir       guifg=#bfbdb6 gui=bold ctermfg=250 cterm=bold
+hi NERDTreeDirSlash  guifg=#ffb454          ctermfg=214
+hi NERDTreeFile      guifg=#ada69c          ctermfg=248
+hi NERDTreeCWD       guifg=#b8522e gui=bold ctermfg=173 cterm=bold
+hi NERDTreeOpenable  guifg=#ffb454          ctermfg=214
+hi NERDTreeClosable  guifg=#ffb454          ctermfg=214
+hi netrwDir          guifg=#ffb454 gui=bold ctermfg=214 cterm=bold
+hi netrwExe          guifg=#b4bc78          ctermfg=143
+hi netrwClassify     guifg=#ffb454          ctermfg=214

--- a/vim/colors/warm-burnout-light.vim
+++ b/vim/colors/warm-burnout-light.vim
@@ -1,0 +1,264 @@
+" Warm Burnout Light -- sepia cream, zero halation
+" Background: #F5EDE0. All tokens >= 4.5:1 contrast (WCAG AA).
+
+hi clear
+if exists('syntax_on')
+  syntax reset
+endif
+
+set background=light
+let g:colors_name = 'warm-burnout-light'
+
+" -- Terminal ANSI colors (16) --
+let g:terminal_ansi_colors = [
+      \ '#3a3630', '#b82820', '#2d6a14', '#8a6000',
+      \ '#2060a0', '#8a3090', '#146858', '#c0b8aa',
+      \ '#686868', '#c83028', '#3a7a20', '#9a7008',
+      \ '#2870b0', '#9a38a0', '#208870', '#faf6f0',
+      \ ]
+
+" -- Editor UI --
+hi Normal           guifg=#3a3630 guibg=#f5ede0 ctermfg=236 ctermbg=230
+hi NormalNC         guifg=#3a3630 guibg=#f5ede0 ctermfg=236 ctermbg=230
+hi NormalFloat      guifg=#3a3630 guibg=#f0e8dc ctermfg=236 ctermbg=255
+hi FloatBorder      guifg=#ddd6ca guibg=#f0e8dc ctermfg=252 ctermbg=255
+hi FloatTitle       guifg=#3a3630 guibg=#f0e8dc gui=bold    ctermfg=236 ctermbg=255 cterm=bold
+hi EndOfBuffer      guifg=#f5ede0 guibg=#f5ede0 ctermfg=230 ctermbg=230
+
+hi Cursor           guifg=#f5ede0 guibg=#8a6600 ctermfg=230 ctermbg=94
+hi lCursor          guifg=#f5ede0 guibg=#8a6600 ctermfg=230 ctermbg=94
+hi CursorIM         guifg=#f5ede0 guibg=#8a6600 ctermfg=230 ctermbg=94
+hi CursorLine                     guibg=#ece4d6             ctermbg=254 cterm=NONE
+hi CursorColumn                   guibg=#ece4d6             ctermbg=254
+hi CursorLineNr     guifg=#6a6258 guibg=NONE    ctermfg=241 ctermbg=NONE
+hi LineNr           guifg=#a89f8c guibg=NONE    ctermfg=248 ctermbg=NONE
+hi SignColumn       guifg=#a89f8c guibg=#f5ede0 ctermfg=248 ctermbg=230
+hi ColorColumn                    guibg=#ece4d6             ctermbg=254
+hi Folded           guifg=#544c40 guibg=#f0e8dc gui=italic  ctermfg=59 ctermbg=255 cterm=italic
+hi FoldColumn       guifg=#a89f8c guibg=NONE    ctermfg=248 ctermbg=NONE
+
+hi VertSplit        guifg=#ddd6ca guibg=NONE    ctermfg=252 ctermbg=NONE
+hi WinSeparator     guifg=#ddd6ca guibg=NONE    ctermfg=252 ctermbg=NONE
+hi StatusLine       guifg=#5c5750 guibg=#ede6da             ctermfg=59 ctermbg=255 cterm=NONE
+hi StatusLineNC     guifg=#a89f8c guibg=#ede6da             ctermfg=248 ctermbg=255 cterm=NONE
+hi TabLine          guifg=#5c5750 guibg=#ede6da             ctermfg=59 ctermbg=255 cterm=NONE
+hi TabLineSel       guifg=#3a3630 guibg=#f5ede0 gui=bold    ctermfg=236 ctermbg=230 cterm=bold
+hi TabLineFill      guifg=#5c5750 guibg=#ede6da             ctermfg=59 ctermbg=255
+
+hi Visual                         guibg=#cfdae2             ctermbg=152
+hi VisualNOS                      guibg=#cfdae2             ctermbg=152
+
+hi Pmenu            guifg=#3a3630 guibg=#f0e8dc             ctermfg=236 ctermbg=255
+hi PmenuSel         guifg=#3a3630 guibg=#cfdae2 gui=bold    ctermfg=236 ctermbg=152 cterm=bold
+hi PmenuSbar                      guibg=#f0e8dc             ctermbg=255
+hi PmenuThumb                     guibg=#a89f8c             ctermbg=248
+hi WildMenu                       guibg=#cfdae2             ctermbg=152
+
+hi Search           guifg=#3a3630 guibg=#e0c890             ctermfg=236 ctermbg=222
+hi IncSearch        guifg=#f5ede0 guibg=#8a6600             ctermfg=230 ctermbg=94
+hi CurSearch        guifg=#f5ede0 guibg=#8a6600             ctermfg=230 ctermbg=94
+hi Substitute       guifg=#f5ede0 guibg=#b03434             ctermfg=230 ctermbg=124
+hi MatchParen       guifg=#b8522e guibg=NONE    gui=bold    ctermfg=173 ctermbg=NONE cterm=bold
+hi QuickFixLine                   guibg=#cfdae2             ctermbg=152
+
+hi SpecialKey       guifg=#a89f8c             ctermfg=248
+hi NonText          guifg=#a89f8c             ctermfg=248
+hi Whitespace       guifg=#a89f8c             ctermfg=248
+hi Conceal          guifg=#5c5750             ctermfg=59
+
+hi Directory        guifg=#855700             ctermfg=94
+hi Title            guifg=#855700 gui=bold    ctermfg=94 cterm=bold
+hi ErrorMsg         guifg=#b03434             ctermfg=124
+hi WarningMsg       guifg=#b8522e             ctermfg=173
+hi MoreMsg          guifg=#285464             ctermfg=24
+hi Question         guifg=#285464             ctermfg=24
+hi ModeMsg          guifg=#3a3630 gui=bold    ctermfg=236 cterm=bold
+
+" -- Spell --
+hi SpellBad   guisp=#b03434 gui=undercurl cterm=undercurl
+hi SpellCap   guisp=#b8522e gui=undercurl cterm=undercurl
+hi SpellLocal guisp=#285464 gui=undercurl cterm=undercurl
+hi SpellRare  guisp=#544c40 gui=undercurl cterm=undercurl
+
+" -- Diff --
+hi DiffAdd                   guibg=#e2ecd8 ctermbg=194
+hi DiffChange                guibg=#dce4ec ctermbg=189
+hi DiffDelete                guibg=#f0d4d4 ctermbg=224
+hi DiffText                  guibg=#c4d4e4 ctermbg=152
+
+" -- Syntax groups --
+hi Comment        guifg=#544c40 gui=italic              ctermfg=59 cterm=italic
+hi Constant       guifg=#7e4060                         ctermfg=89
+hi String         guifg=#4d5c1a                         ctermfg=58
+hi Character      guifg=#4d5c1a                         ctermfg=58
+hi Number         guifg=#7e4060                         ctermfg=89
+hi Boolean        guifg=#7e4060                         ctermfg=89
+hi Float          guifg=#7e4060                         ctermfg=89
+hi Identifier     guifg=#3a3630                         ctermfg=236 cterm=NONE
+hi Function       guifg=#855700                         ctermfg=94
+hi Statement      guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi Conditional    guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi Repeat         guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi Label          guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi Operator       guifg=#8f4418                         ctermfg=94
+hi Keyword        guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi Exception      guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi PreProc        guifg=#924800                         ctermfg=94
+hi Include        guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi Define         guifg=#924800                         ctermfg=94
+hi Macro          guifg=#7a5a1c                         ctermfg=58
+hi PreCondit      guifg=#924800                         ctermfg=94
+hi Type           guifg=#285464 gui=italic              ctermfg=24 cterm=italic
+hi StorageClass   guifg=#924800 gui=bold                ctermfg=94 cterm=bold
+hi Structure      guifg=#285464 gui=italic              ctermfg=24 cterm=italic
+hi Typedef        guifg=#285464 gui=italic              ctermfg=24 cterm=italic
+hi Special        guifg=#8f4418                         ctermfg=94
+hi SpecialChar    guifg=#286a48                         ctermfg=23
+hi Tag            guifg=#8e4632 gui=bold                ctermfg=95 cterm=bold
+hi Delimiter      guifg=#3a3630                         ctermfg=236
+hi SpecialComment guifg=#544c40 gui=italic              ctermfg=59 cterm=italic
+hi Debug          guifg=#b8522e                         ctermfg=173
+hi Underlined                   gui=underline          cterm=underline
+hi Ignore         guifg=#5c5750                         ctermfg=59
+hi Error          guifg=#b03434                         ctermfg=124
+hi Todo           guifg=#8a6600 gui=bold                ctermfg=94 cterm=bold
+hi Added          guifg=#226414                         ctermfg=22
+hi Changed        guifg=#2868a0                         ctermfg=25
+hi Removed        guifg=#c43040                         ctermfg=160
+
+" -- LSP / Diagnostics --
+hi DiagnosticError      guifg=#b03434 ctermfg=124
+hi DiagnosticWarn       guifg=#b8522e ctermfg=173
+hi DiagnosticInfo       guifg=#285464 ctermfg=24
+hi DiagnosticHint       guifg=#544c40 ctermfg=59
+hi DiagnosticOk         guifg=#226414 ctermfg=22
+hi DiagnosticSignError  guifg=#b03434 ctermfg=124
+hi DiagnosticSignWarn   guifg=#b8522e ctermfg=173
+hi DiagnosticSignInfo   guifg=#285464 ctermfg=24
+hi DiagnosticSignHint   guifg=#544c40 ctermfg=59
+hi DiagnosticUnderlineError guisp=#b03434 gui=undercurl cterm=undercurl
+hi DiagnosticUnderlineWarn  guisp=#b8522e gui=undercurl cterm=undercurl
+hi DiagnosticUnderlineInfo  guisp=#285464 gui=undercurl cterm=undercurl
+hi DiagnosticUnderlineHint  guisp=#544c40 gui=undercurl cterm=undercurl
+hi DiagnosticVirtualTextError guifg=#b03434 ctermfg=124
+hi DiagnosticVirtualTextWarn  guifg=#b8522e ctermfg=173
+hi DiagnosticVirtualTextInfo  guifg=#285464 ctermfg=24
+hi DiagnosticVirtualTextHint  guifg=#544c40 ctermfg=59
+
+hi ALEErrorSign        guifg=#b03434 ctermfg=124
+hi ALEWarningSign      guifg=#b8522e ctermfg=173
+hi ALEInfoSign         guifg=#285464 ctermfg=24
+hi ALEError            guisp=#b03434 gui=undercurl cterm=undercurl
+hi ALEWarning          guisp=#b8522e gui=undercurl cterm=undercurl
+
+hi CocErrorSign   guifg=#b03434 ctermfg=124
+hi CocWarningSign guifg=#b8522e ctermfg=173
+hi CocInfoSign    guifg=#285464 ctermfg=24
+hi CocHintSign    guifg=#544c40 ctermfg=59
+hi CocErrorFloat  guifg=#b03434 ctermfg=124
+hi CocErrorHighlight   guisp=#b03434 gui=undercurl cterm=undercurl
+hi CocWarningHighlight guisp=#b8522e gui=undercurl cterm=undercurl
+
+" -- Git --
+hi GitGutterAdd    guifg=#226414 ctermfg=22
+hi GitGutterChange guifg=#2868a0 ctermfg=25
+hi GitGutterDelete guifg=#c43040 ctermfg=160
+hi SignifySignAdd    guifg=#226414 ctermfg=22
+hi SignifySignChange guifg=#2868a0 ctermfg=25
+hi SignifySignDelete guifg=#c43040 ctermfg=160
+hi diffAdded   guifg=#226414 ctermfg=22
+hi diffRemoved guifg=#c43040 ctermfg=160
+hi diffChanged guifg=#2868a0 ctermfg=25
+
+" -- HTML / XML --
+hi htmlTag        guifg=#8e4632 gui=bold ctermfg=95 cterm=bold
+hi htmlEndTag     guifg=#8e4632 gui=bold ctermfg=95 cterm=bold
+hi htmlTagName    guifg=#8e4632 gui=bold ctermfg=95 cterm=bold
+hi htmlArg        guifg=#855700          ctermfg=94
+hi htmlTitle      guifg=#3a3630 gui=bold ctermfg=236 cterm=bold
+hi htmlH1         guifg=#3a3630 gui=bold ctermfg=236 cterm=bold
+hi xmlTag         guifg=#8e4632 gui=bold ctermfg=95 cterm=bold
+hi xmlTagName     guifg=#8e4632 gui=bold ctermfg=95 cterm=bold
+hi xmlEndTag      guifg=#8e4632 gui=bold ctermfg=95 cterm=bold
+
+" -- CSS --
+hi cssClassName    guifg=#7a5a1c gui=italic ctermfg=58 cterm=italic
+hi cssIdentifier   guifg=#7a5a1c gui=italic ctermfg=58 cterm=italic
+hi cssProp         guifg=#74501c gui=italic ctermfg=94 cterm=italic
+hi cssAttr         guifg=#4d5c1a            ctermfg=58
+hi cssAttrRegion   guifg=#4d5c1a            ctermfg=58
+hi cssBraces       guifg=#3a3630            ctermfg=236
+hi cssPseudoClass  guifg=#883850            ctermfg=89
+hi cssPseudoClassId guifg=#883850           ctermfg=89
+hi cssValueLength  guifg=#7e4060            ctermfg=89
+hi cssValueNumber  guifg=#7e4060            ctermfg=89
+hi cssFunctionName guifg=#855700            ctermfg=94
+hi cssColor        guifg=#7e4060            ctermfg=89
+
+" -- JavaScript / TypeScript --
+hi jsFunction         guifg=#924800 gui=bold  ctermfg=94 cterm=bold
+hi jsFuncCall         guifg=#855700           ctermfg=94
+hi jsClassDefinition  guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi jsGlobalObjects    guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi jsThis             guifg=#8e4632 gui=italic ctermfg=95 cterm=italic
+hi jsObjectKey        guifg=#74501c gui=italic ctermfg=94 cterm=italic
+hi typescriptKeyword     guifg=#924800 gui=bold ctermfg=94 cterm=bold
+hi typescriptClassName   guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi typescriptFuncKeyword guifg=#924800 gui=bold ctermfg=94 cterm=bold
+hi typescriptMember      guifg=#883850          ctermfg=89
+
+" -- Python --
+hi pythonBuiltin     guifg=#883850           ctermfg=89
+hi pythonFunction    guifg=#855700           ctermfg=94
+hi pythonDecorator   guifg=#7a5a1c gui=italic ctermfg=58 cterm=italic
+hi pythonDecoratorName guifg=#7a5a1c gui=italic ctermfg=58 cterm=italic
+hi pythonStatement   guifg=#924800 gui=bold  ctermfg=94 cterm=bold
+hi pythonClass       guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi pythonSelf        guifg=#8e4632 gui=italic ctermfg=95 cterm=italic
+
+" -- Rust --
+hi rustKeyword         guifg=#924800 gui=bold ctermfg=94 cterm=bold
+hi rustType            guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi rustTrait           guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi rustMacro           guifg=#7a5a1c          ctermfg=58
+hi rustAttribute       guifg=#7a5a1c gui=italic ctermfg=58 cterm=italic
+hi rustLifetime        guifg=#8e4632 gui=italic ctermfg=95 cterm=italic
+hi rustFuncCall        guifg=#855700          ctermfg=94
+hi rustFuncName        guifg=#855700          ctermfg=94
+hi rustEnumVariant     guifg=#7e4060          ctermfg=89
+
+" -- Markdown --
+hi markdownH1        guifg=#924800 gui=bold ctermfg=94 cterm=bold
+hi markdownH2        guifg=#855700 gui=bold ctermfg=94 cterm=bold
+hi markdownH3        guifg=#7a5a1c gui=bold ctermfg=58 cterm=bold
+hi markdownH4        guifg=#4d5c1a gui=bold ctermfg=58 cterm=bold
+hi markdownH5        guifg=#285464 gui=bold ctermfg=24 cterm=bold
+hi markdownH6        guifg=#8e4632 gui=bold ctermfg=95 cterm=bold
+hi markdownCode      guifg=#4d5c1a          ctermfg=58
+hi markdownCodeBlock guifg=#4d5c1a          ctermfg=58
+hi markdownLinkText  guifg=#8e4632 gui=underline ctermfg=95 cterm=underline
+hi markdownUrl       guifg=#285464 gui=underline ctermfg=24 cterm=underline
+hi markdownBold      guifg=#3a3630 gui=bold ctermfg=236 cterm=bold
+hi markdownItalic    guifg=#883850 gui=italic ctermfg=89 cterm=italic
+hi markdownListMarker guifg=#855700         ctermfg=94
+
+" -- Vim --
+hi vimCommand    guifg=#924800 gui=bold ctermfg=94 cterm=bold
+hi vimFunction   guifg=#855700          ctermfg=94
+hi vimFuncName   guifg=#855700          ctermfg=94
+hi vimGroup      guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi vimHiGroup    guifg=#285464 gui=italic ctermfg=24 cterm=italic
+hi vimOption     guifg=#74501c gui=italic ctermfg=94 cterm=italic
+hi vimVar        guifg=#7e4060          ctermfg=89
+hi vimNotation   guifg=#286a48          ctermfg=23
+
+" -- NERDTree / netrw --
+hi NERDTreeDir       guifg=#3a3630 gui=bold ctermfg=236 cterm=bold
+hi NERDTreeDirSlash  guifg=#855700          ctermfg=94
+hi NERDTreeFile      guifg=#5c5750          ctermfg=59
+hi NERDTreeCWD       guifg=#b8522e gui=bold ctermfg=173 cterm=bold
+hi NERDTreeOpenable  guifg=#855700          ctermfg=94
+hi NERDTreeClosable  guifg=#855700          ctermfg=94
+hi netrwDir          guifg=#855700 gui=bold ctermfg=94 cterm=bold
+hi netrwExe          guifg=#4d5c1a          ctermfg=58
+hi netrwClassify     guifg=#855700          ctermfg=94


### PR DESCRIPTION
Classic vimscript colorscheme mirroring the nvim platform. Self-contained dark and light variants with GUI truecolor and 256-color fallback, 16-color terminal ANSI palette, and highlights for ALE, coc.nvim, vim-gitgutter, vim-signify, NERDTree, and netrw. The font style system (bold keywords, italic types/comments) is preserved across both gui= and cterm= attributes.