### PR TITLE
Add alacritty port

### DIFF
--- a/.github/workflows/release-themes.yml
+++ b/.github/workflows/release-themes.yml
@@ -107,6 +107,13 @@ jobs:
             warm-burnout-dark.yaml \
             warm-burnout-light.yaml
 
+      - name: Package Alacritty
+        run: |
+          cd alacritty
+          zip -j ../warm-burnout-alacritty.zip \
+            warm-burnout-dark.toml \
+            warm-burnout-light.toml
+
       - name: Package tmux
         run: |
           cd tmux
@@ -157,6 +164,7 @@ jobs:
             warm-burnout-iterm2.zip
             warm-burnout-windows-terminal.zip
             warm-burnout-warp.zip
+            warm-burnout-alacritty.zip
             warm-burnout-tmux.zip
             warm-burnout-zellij.zip
             warm-burnout-eza.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ warm-burnout/
     jetbrains.rs              # JetBrains theme validation tests
     windows_terminal.rs       # Windows Terminal theme validation tests
     warp.rs                   # Warp theme validation tests
+    alacritty.rs              # Alacritty theme validation tests
     tmux.rs                   # tmux theme validation tests
     zellij.rs                 # Zellij theme validation tests
     zsh.rs                    # Zsh theme validation tests
@@ -130,6 +131,11 @@ warm-burnout/
     AGENTS.md                 # Warp-specific agent rules
     warm-burnout-dark.yaml    # Dark variant
     warm-burnout-light.yaml   # Light variant
+  alacritty/                  # Alacritty terminal theme
+    README.md                 # Alacritty install instructions
+    AGENTS.md                 # Alacritty-specific agent rules
+    warm-burnout-dark.toml    # Dark variant (TOML, importable)
+    warm-burnout-light.toml   # Light variant
   tmux/                       # tmux status bar theme
     README.md                 # tmux install instructions
     AGENTS.md                 # tmux-specific agent rules

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Inspired by materials that age well. Unlike your eyes.
 | iTerm2 | Available | [`iterm2/`](iterm2/) |
 | Windows Terminal | Available | [`windows-terminal/`](windows-terminal/) |
 | Warp | Available | [`warp/`](warp/) |
+| Alacritty | Available | [`alacritty/`](alacritty/) |
 | tmux | Available | [`tmux/`](tmux/) |
 | Zellij | Available | [`zellij/`](zellij/) |
 | Starship | Available | [`starship/`](starship/) |

--- a/alacritty/AGENTS.md
+++ b/alacritty/AGENTS.md
@@ -1,0 +1,51 @@
+# Alacritty -- Agent Instructions
+
+## Platform Reference
+
+See the root [`AGENTS.md`](../AGENTS.md) for the canonical palette, design principles, and brand rules. Do not duplicate palette tables here.
+
+## Alacritty Theme Format
+
+- Theme files are TOML (`.toml`). Alacritty switched its config format from YAML to TOML in 0.13 and dropped YAML entirely in 0.14.
+- Imported by another config via `general.import` (Alacritty >= 0.15) or top-level `import` (older versions). Both forms accept absolute paths or `~`-prefixed paths.
+- Conventional install location: `~/.config/alacritty/themes/`. On Windows: `%APPDATA%\alacritty\themes\`.
+
+## Color Mapping
+
+Core blocks (`primary`, `cursor`, `selection`, `normal`, `bright`) come verbatim from the Ghostty + Windows Terminal themes so all sibling terminal emulators render identically:
+
+| Alacritty Key | Canonical Source |
+|---------------|-----------------|
+| `colors.primary.background` | Editor background (`#1a1510` dark, `#f5ede0` light) |
+| `colors.primary.foreground` | Editor foreground (`#bfbdb6` dark, `#3a3630` light) |
+| `colors.primary.bright_foreground` | Same as foreground -- bold must not punch up to harsh white |
+| `colors.cursor.cursor` | Canonical cursor (`#f5c56e` dark, `#8a6600` light) |
+| `colors.cursor.text` | Same as background |
+| `colors.selection.background` | Opaque selection blend (`#33393a` dark, `#e5e8e2` light) |
+| `colors.selection.text` | Same as foreground |
+| `colors.normal.*` / `colors.bright.*` | Ghostty `palette = 0..15` |
+
+Extended UI uses canonical palette hex values only. No off-palette tints:
+
+| Alacritty Key | Canonical Source |
+|---------------|-----------------|
+| `colors.vi_mode_cursor.cursor` / `.text` | Canonical cursor / background |
+| `colors.search.matches` | Functions token (`#ffb454` dark / `#855700` light) on background |
+| `colors.search.focused_match` | Keywords token (`#ff8f40` dark / `#924800` light) on background |
+| `colors.footer_bar.foreground` | Comments token (`#b4a89c` dark / `#544c40` light) |
+| `colors.footer_bar.background` | Recessed chrome below editor bg (`#14120f` dark / `#ede6da` light) |
+| `colors.hints.start` / `.hints.end` | Types token (`#90aec0` dark / `#285464` light) -- the one sanctioned cool accent, matches iTerm2 Link Color |
+
+## Selection Color Note
+
+Alacritty does not honour alpha in `colors.selection.background`. Use the opaque blends listed above (the same values Ghostty uses for the same reason). They are pre-mixed approximations of the steel-patina selection at 25% over the editor background.
+
+## Bright Foreground Note
+
+`bright_foreground` is set explicitly to the same value as `foreground`. When `draw_bold_text_with_bright_colors` is enabled (Alacritty's default for some setups), bold text would otherwise jump to `bright.white`, which is `#ffffff` on dark and a near-white on light. Both punch through the warm palette. Mirroring iTerm2's Bold Color choice keeps bold weight visible without the luminance spike.
+
+## File Naming
+
+- Dark theme: `warm-burnout-dark.toml`
+- Light theme: `warm-burnout-light.toml`
+- Filenames double as the import path -- keep them stable.

--- a/alacritty/README.md
+++ b/alacritty/README.md
@@ -1,0 +1,41 @@
+# Warm Burnout for Alacritty
+
+Even the GPU-rendered terminal was burning your retinas. The burnout is spreading.
+
+## Install
+
+Drop the TOML files into Alacritty's themes directory:
+
+```sh
+mkdir -p ~/.config/alacritty/themes
+cp warm-burnout-dark.toml warm-burnout-light.toml ~/.config/alacritty/themes/
+```
+
+Windows: `%APPDATA%\alacritty\themes\`.
+
+## Configure
+
+Add an import to your `~/.config/alacritty/alacritty.toml`.
+
+Alacritty 0.15 and newer:
+
+```toml
+[general]
+import = ["~/.config/alacritty/themes/warm-burnout-dark.toml"]
+```
+
+Alacritty 0.13 and 0.14:
+
+```toml
+import = ["~/.config/alacritty/themes/warm-burnout-dark.toml"]
+```
+
+Swap `warm-burnout-dark.toml` for `warm-burnout-light.toml` when you give in to daylight. Alacritty live-reloads the config on save, so no restart needed.
+
+## Verify
+
+Run `ls --color` or any ANSI color test script. Warm browns instead of searing blues. Vi-mode search highlights should glow amber, hints should land on the canonical copper-patina type accent.
+
+## Palette
+
+Both themes derive from the canonical Warm Burnout palette defined in the root [`AGENTS.md`](../AGENTS.md). The 16 ANSI colors and the editor background, foreground, and cursor match the Ghostty theme exactly. The extended UI block (`vi_mode_cursor`, `search`, `footer_bar`, `hints`) uses canonical palette hex values only, with no off-palette tints.

--- a/alacritty/warm-burnout-dark.toml
+++ b/alacritty/warm-burnout-dark.toml
@@ -1,0 +1,58 @@
+# Warm Burnout Dark
+
+[colors.primary]
+background        = "#1a1510"
+foreground        = "#bfbdb6"
+bright_foreground = "#bfbdb6"
+
+[colors.cursor]
+cursor = "#f5c56e"
+text   = "#1a1510"
+
+[colors.selection]
+background = "#33393a"
+text       = "#bfbdb6"
+
+[colors.normal]
+black   = "#23211b"
+red     = "#f06b73"
+green   = "#70bf56"
+yellow  = "#fdb04c"
+blue    = "#4fbfff"
+magenta = "#d0a1ff"
+cyan    = "#93e2c8"
+white   = "#c7c7c7"
+
+[colors.bright]
+black   = "#686868"
+red     = "#f07178"
+green   = "#aad94c"
+yellow  = "#ffb454"
+blue    = "#59c2ff"
+magenta = "#d2a6ff"
+cyan    = "#95e6cb"
+white   = "#ffffff"
+
+[colors.vi_mode_cursor]
+cursor = "#f5c56e"
+text   = "#1a1510"
+
+[colors.search.matches]
+foreground = "#1a1510"
+background = "#ffb454"
+
+[colors.search.focused_match]
+foreground = "#1a1510"
+background = "#ff8f40"
+
+[colors.footer_bar]
+foreground = "#b4a89c"
+background = "#14120f"
+
+[colors.hints.start]
+foreground = "#1a1510"
+background = "#90aec0"
+
+[colors.hints.end]
+foreground = "#90aec0"
+background = "#1a1510"

--- a/alacritty/warm-burnout-light.toml
+++ b/alacritty/warm-burnout-light.toml
@@ -1,0 +1,58 @@
+# Warm Burnout Light
+
+[colors.primary]
+background        = "#f5ede0"
+foreground        = "#3a3630"
+bright_foreground = "#3a3630"
+
+[colors.cursor]
+cursor = "#8a6600"
+text   = "#f5ede0"
+
+[colors.selection]
+background = "#e5e8e2"
+text       = "#3a3630"
+
+[colors.normal]
+black   = "#3a3630"
+red     = "#b82820"
+green   = "#2d6a14"
+yellow  = "#8a6000"
+blue    = "#2060a0"
+magenta = "#8a3090"
+cyan    = "#146858"
+white   = "#c0b8aa"
+
+[colors.bright]
+black   = "#686868"
+red     = "#c83028"
+green   = "#3a7a20"
+yellow  = "#9a7008"
+blue    = "#2870b0"
+magenta = "#9a38a0"
+cyan    = "#208870"
+white   = "#faf6f0"
+
+[colors.vi_mode_cursor]
+cursor = "#8a6600"
+text   = "#f5ede0"
+
+[colors.search.matches]
+foreground = "#f5ede0"
+background = "#855700"
+
+[colors.search.focused_match]
+foreground = "#f5ede0"
+background = "#924800"
+
+[colors.footer_bar]
+foreground = "#544c40"
+background = "#ede6da"
+
+[colors.hints.start]
+foreground = "#f5ede0"
+background = "#285464"
+
+[colors.hints.end]
+foreground = "#285464"
+background = "#f5ede0"

--- a/site/index.html
+++ b/site/index.html
@@ -51,7 +51,7 @@
     },
     "license": "https://opensource.org/licenses/MIT",
     "screenshot": "https://warmburnout.com/og-image.png",
-    "softwareRequirements": "VS Code, Open VSX (Antigravity, Cursor, Windsurf, Kiro, VSCodium), JetBrains IDEs, Neovim, Ghostty, Zed, Xcode, iTerm2, Windows Terminal, Warp, tmux, Zellij, Starship, Zsh, Home Assistant, eza, or Obsidian",
+    "softwareRequirements": "VS Code, Open VSX (Antigravity, Cursor, Windsurf, Kiro, VSCodium), JetBrains IDEs, Neovim, Ghostty, Zed, Xcode, iTerm2, Windows Terminal, Warp, Alacritty, tmux, Zellij, Starship, Zsh, Home Assistant, eza, or Obsidian",
     "image": "https://warmburnout.com/og-image.png"
   }
   </script>
@@ -434,6 +434,12 @@
 
           <a href="https://github.com/felipefdl/warm-burnout/tree/main/warp" class="retro-card rounded-md p-4 no-underline block">
             <p class="text-sm font-bold theme-fg">Warp</p>
+            <p class="text-xs theme-fg-muted mt-1">Terminal</p>
+            <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
+          </a>
+
+          <a href="https://github.com/felipefdl/warm-burnout/tree/main/alacritty" class="retro-card rounded-md p-4 no-underline block">
+            <p class="text-sm font-bold theme-fg">Alacritty</p>
             <p class="text-xs theme-fg-muted mt-1">Terminal</p>
             <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
           </a>

--- a/tests/alacritty.rs
+++ b/tests/alacritty.rs
@@ -1,0 +1,404 @@
+mod common;
+
+use common::{alacritty_color, extract_hex_colors, ghostty_ansi_color, ghostty_color, is_valid_hex};
+
+const DARK: &str = include_str!("../alacritty/warm-burnout-dark.toml");
+const LIGHT: &str = include_str!("../alacritty/warm-burnout-light.toml");
+
+const GHOSTTY_DARK: &str = include_str!("../ghostty/warm-burnout-dark");
+const GHOSTTY_LIGHT: &str = include_str!("../ghostty/warm-burnout-light");
+
+const ANSI_KEYS: &[&str] = &["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"];
+
+const REQUIRED_TABLES: &[&str] = &[
+  "colors.primary",
+  "colors.cursor",
+  "colors.selection",
+  "colors.normal",
+  "colors.bright",
+  "colors.vi_mode_cursor",
+  "colors.search.matches",
+  "colors.search.focused_match",
+  "colors.footer_bar",
+  "colors.hints.start",
+  "colors.hints.end",
+];
+
+fn parse_toml(src: &str) -> toml::Table {
+  src.parse::<toml::Table>().expect("invalid TOML")
+}
+
+// -- Valid TOML --
+
+#[test]
+fn dark_is_valid_toml() {
+  parse_toml(DARK);
+}
+
+#[test]
+fn light_is_valid_toml() {
+  parse_toml(LIGHT);
+}
+
+// -- All hex colors in the file are valid --
+
+#[test]
+fn dark_all_hex_colors_are_valid() {
+  for (line, hex) in extract_hex_colors(DARK) {
+    assert!(is_valid_hex(hex), "dark line {line}: invalid hex: {hex}");
+  }
+}
+
+#[test]
+fn light_all_hex_colors_are_valid() {
+  for (line, hex) in extract_hex_colors(LIGHT) {
+    assert!(is_valid_hex(hex), "light line {line}: invalid hex: {hex}");
+  }
+}
+
+// -- Required tables present --
+
+fn assert_path_exists(src: &str, path: &str, variant: &str) {
+  let table = parse_toml(src);
+  let mut value: toml::Value = toml::Value::Table(table);
+  for part in path.split('.') {
+    value = match value.get(part) {
+      Some(v) => v.clone(),
+      None => panic!("{variant}: missing required table path '{path}' (failed at '{part}')"),
+    };
+  }
+  assert!(value.is_table(), "{variant}: '{path}' exists but is not a table");
+}
+
+#[test]
+fn dark_has_all_required_tables() {
+  for path in REQUIRED_TABLES {
+    assert_path_exists(DARK, path, "dark");
+  }
+}
+
+#[test]
+fn light_has_all_required_tables() {
+  for path in REQUIRED_TABLES {
+    assert_path_exists(LIGHT, path, "light");
+  }
+}
+
+// -- Canonical chrome --
+
+#[test]
+fn dark_background_is_canonical() {
+  assert_eq!(alacritty_color(DARK, "colors.primary.background"), "#1a1510");
+}
+
+#[test]
+fn light_background_is_canonical() {
+  assert_eq!(alacritty_color(LIGHT, "colors.primary.background"), "#f5ede0");
+}
+
+#[test]
+fn dark_foreground_is_canonical() {
+  assert_eq!(alacritty_color(DARK, "colors.primary.foreground"), "#bfbdb6");
+}
+
+#[test]
+fn light_foreground_is_canonical() {
+  assert_eq!(alacritty_color(LIGHT, "colors.primary.foreground"), "#3a3630");
+}
+
+#[test]
+fn dark_cursor_is_canonical() {
+  assert_eq!(alacritty_color(DARK, "colors.cursor.cursor"), "#f5c56e");
+}
+
+#[test]
+fn light_cursor_is_canonical() {
+  assert_eq!(alacritty_color(LIGHT, "colors.cursor.cursor"), "#8a6600");
+}
+
+// -- Cross-platform: chrome matches Ghostty --
+
+#[test]
+fn dark_background_matches_ghostty() {
+  let alac = alacritty_color(DARK, "colors.primary.background");
+  let ghostty = ghostty_color(GHOSTTY_DARK, "background");
+  assert_eq!(alac, ghostty, "dark background: alacritty={alac} ghostty={ghostty}");
+}
+
+#[test]
+fn light_background_matches_ghostty() {
+  let alac = alacritty_color(LIGHT, "colors.primary.background");
+  let ghostty = ghostty_color(GHOSTTY_LIGHT, "background");
+  assert_eq!(alac, ghostty, "light background: alacritty={alac} ghostty={ghostty}");
+}
+
+#[test]
+fn dark_foreground_matches_ghostty() {
+  let alac = alacritty_color(DARK, "colors.primary.foreground");
+  let ghostty = ghostty_color(GHOSTTY_DARK, "foreground");
+  assert_eq!(alac, ghostty, "dark foreground: alacritty={alac} ghostty={ghostty}");
+}
+
+#[test]
+fn light_foreground_matches_ghostty() {
+  let alac = alacritty_color(LIGHT, "colors.primary.foreground");
+  let ghostty = ghostty_color(GHOSTTY_LIGHT, "foreground");
+  assert_eq!(alac, ghostty, "light foreground: alacritty={alac} ghostty={ghostty}");
+}
+
+#[test]
+fn dark_cursor_matches_ghostty() {
+  let alac = alacritty_color(DARK, "colors.cursor.cursor");
+  let ghostty = ghostty_color(GHOSTTY_DARK, "cursor-color");
+  assert_eq!(alac, ghostty, "dark cursor: alacritty={alac} ghostty={ghostty}");
+}
+
+#[test]
+fn light_cursor_matches_ghostty() {
+  let alac = alacritty_color(LIGHT, "colors.cursor.cursor");
+  let ghostty = ghostty_color(GHOSTTY_LIGHT, "cursor-color");
+  assert_eq!(alac, ghostty, "light cursor: alacritty={alac} ghostty={ghostty}");
+}
+
+// -- Cursor text matches background (readable cursor character) --
+
+#[test]
+fn dark_cursor_text_matches_background() {
+  assert_eq!(
+    alacritty_color(DARK, "colors.cursor.text"),
+    alacritty_color(DARK, "colors.primary.background"),
+    "dark cursor.text should match background for readability"
+  );
+}
+
+#[test]
+fn light_cursor_text_matches_background() {
+  assert_eq!(
+    alacritty_color(LIGHT, "colors.cursor.text"),
+    alacritty_color(LIGHT, "colors.primary.background"),
+    "light cursor.text should match background for readability"
+  );
+}
+
+// -- bright_foreground equals foreground --
+// Bold text must not punch up to harsh white. See alacritty/AGENTS.md.
+
+#[test]
+fn dark_bright_foreground_matches_foreground() {
+  assert_eq!(
+    alacritty_color(DARK, "colors.primary.bright_foreground"),
+    alacritty_color(DARK, "colors.primary.foreground"),
+    "dark bright_foreground must equal foreground (no luminance spike on bold)"
+  );
+}
+
+#[test]
+fn light_bright_foreground_matches_foreground() {
+  assert_eq!(
+    alacritty_color(LIGHT, "colors.primary.bright_foreground"),
+    alacritty_color(LIGHT, "colors.primary.foreground"),
+    "light bright_foreground must equal foreground (no luminance spike on bold)"
+  );
+}
+
+// -- Selection: opaque blend (alpha not honoured by Alacritty) --
+
+#[test]
+fn dark_selection_background_is_canonical_opaque_blend() {
+  assert_eq!(alacritty_color(DARK, "colors.selection.background"), "#33393a");
+}
+
+#[test]
+fn light_selection_background_is_canonical_opaque_blend() {
+  assert_eq!(alacritty_color(LIGHT, "colors.selection.background"), "#e5e8e2");
+}
+
+#[test]
+fn dark_selection_text_matches_foreground() {
+  assert_eq!(
+    alacritty_color(DARK, "colors.selection.text"),
+    alacritty_color(DARK, "colors.primary.foreground"),
+  );
+}
+
+#[test]
+fn light_selection_text_matches_foreground() {
+  assert_eq!(
+    alacritty_color(LIGHT, "colors.selection.text"),
+    alacritty_color(LIGHT, "colors.primary.foreground"),
+  );
+}
+
+// -- ANSI palette matches Ghostty --
+
+fn assert_ansi_bank_matches_ghostty(src: &str, ghostty_src: &str, bank: &str, base: u8, variant: &str) {
+  for (offset, name) in ANSI_KEYS.iter().enumerate() {
+    let alac = alacritty_color(src, &format!("colors.{bank}.{name}"));
+    let ghostty = ghostty_ansi_color(ghostty_src, base + offset as u8);
+    assert_eq!(
+      alac,
+      ghostty,
+      "{variant} {bank}.{name} (palette {}): alacritty={alac} ghostty={ghostty}",
+      base + offset as u8
+    );
+  }
+}
+
+#[test]
+fn dark_normal_ansi_matches_ghostty() {
+  assert_ansi_bank_matches_ghostty(DARK, GHOSTTY_DARK, "normal", 0, "dark");
+}
+
+#[test]
+fn dark_bright_ansi_matches_ghostty() {
+  assert_ansi_bank_matches_ghostty(DARK, GHOSTTY_DARK, "bright", 8, "dark");
+}
+
+#[test]
+fn light_normal_ansi_matches_ghostty() {
+  assert_ansi_bank_matches_ghostty(LIGHT, GHOSTTY_LIGHT, "normal", 0, "light");
+}
+
+#[test]
+fn light_bright_ansi_matches_ghostty() {
+  assert_ansi_bank_matches_ghostty(LIGHT, GHOSTTY_LIGHT, "bright", 8, "light");
+}
+
+// -- vi_mode cursor matches canonical cursor --
+
+#[test]
+fn dark_vi_mode_cursor_matches_canonical() {
+  assert_eq!(alacritty_color(DARK, "colors.vi_mode_cursor.cursor"), "#f5c56e");
+  assert_eq!(alacritty_color(DARK, "colors.vi_mode_cursor.text"), "#1a1510");
+}
+
+#[test]
+fn light_vi_mode_cursor_matches_canonical() {
+  assert_eq!(alacritty_color(LIGHT, "colors.vi_mode_cursor.cursor"), "#8a6600");
+  assert_eq!(alacritty_color(LIGHT, "colors.vi_mode_cursor.text"), "#f5ede0");
+}
+
+// -- Search highlights use canonical functions / keywords tokens --
+
+#[test]
+fn dark_search_matches_use_canonical_functions_token() {
+  assert_eq!(alacritty_color(DARK, "colors.search.matches.background"), "#ffb454");
+  assert_eq!(alacritty_color(DARK, "colors.search.matches.foreground"), "#1a1510");
+}
+
+#[test]
+fn light_search_matches_use_canonical_functions_token() {
+  assert_eq!(alacritty_color(LIGHT, "colors.search.matches.background"), "#855700");
+  assert_eq!(alacritty_color(LIGHT, "colors.search.matches.foreground"), "#f5ede0");
+}
+
+#[test]
+fn dark_search_focused_match_uses_canonical_keywords_token() {
+  assert_eq!(
+    alacritty_color(DARK, "colors.search.focused_match.background"),
+    "#ff8f40"
+  );
+  assert_eq!(
+    alacritty_color(DARK, "colors.search.focused_match.foreground"),
+    "#1a1510"
+  );
+}
+
+#[test]
+fn light_search_focused_match_uses_canonical_keywords_token() {
+  assert_eq!(
+    alacritty_color(LIGHT, "colors.search.focused_match.background"),
+    "#924800"
+  );
+  assert_eq!(
+    alacritty_color(LIGHT, "colors.search.focused_match.foreground"),
+    "#f5ede0"
+  );
+}
+
+// -- Footer bar uses canonical comments token --
+
+#[test]
+fn dark_footer_bar_foreground_is_canonical_comments_token() {
+  assert_eq!(alacritty_color(DARK, "colors.footer_bar.foreground"), "#b4a89c");
+}
+
+#[test]
+fn light_footer_bar_foreground_is_canonical_comments_token() {
+  assert_eq!(alacritty_color(LIGHT, "colors.footer_bar.foreground"), "#544c40");
+}
+
+// -- Hints use the one sanctioned cool accent (canonical types token) --
+
+#[test]
+fn dark_hints_start_uses_canonical_types_token() {
+  assert_eq!(alacritty_color(DARK, "colors.hints.start.background"), "#90aec0");
+  assert_eq!(alacritty_color(DARK, "colors.hints.start.foreground"), "#1a1510");
+}
+
+#[test]
+fn light_hints_start_uses_canonical_types_token() {
+  assert_eq!(alacritty_color(LIGHT, "colors.hints.start.background"), "#285464");
+  assert_eq!(alacritty_color(LIGHT, "colors.hints.start.foreground"), "#f5ede0");
+}
+
+#[test]
+fn dark_hints_end_uses_canonical_types_token() {
+  assert_eq!(alacritty_color(DARK, "colors.hints.end.foreground"), "#90aec0");
+}
+
+#[test]
+fn light_hints_end_uses_canonical_types_token() {
+  assert_eq!(alacritty_color(LIGHT, "colors.hints.end.foreground"), "#285464");
+}
+
+// -- Background sanity: no pure black, no pure white --
+
+#[test]
+fn dark_no_pure_black_background() {
+  assert_ne!(
+    alacritty_color(DARK, "colors.primary.background"),
+    "#000000",
+    "dark background must not be pure black (halation risk)"
+  );
+}
+
+#[test]
+fn light_no_pure_white_background() {
+  assert_ne!(
+    alacritty_color(LIGHT, "colors.primary.background"),
+    "#ffffff",
+    "light background must not be pure white (luminance overload)"
+  );
+}
+
+// -- Brand rule: warm everywhere, blue nowhere (chrome only). --
+// ANSI blue must literally exist in colors.normal/bright, so we exclude those.
+
+#[test]
+fn dark_no_canonical_steel_blue_in_chrome() {
+  for path in [
+    "colors.primary.background",
+    "colors.primary.foreground",
+    "colors.cursor.cursor",
+    "colors.footer_bar.background",
+    "colors.footer_bar.foreground",
+  ] {
+    let val = alacritty_color(DARK, path);
+    assert_ne!(val, "#90aec0", "dark {path} must not be canonical steel-blue");
+  }
+}
+
+#[test]
+fn light_no_canonical_steel_blue_in_chrome() {
+  for path in [
+    "colors.primary.background",
+    "colors.primary.foreground",
+    "colors.cursor.cursor",
+    "colors.footer_bar.background",
+    "colors.footer_bar.foreground",
+  ] {
+    let val = alacritty_color(LIGHT, path);
+    assert_ne!(val, "#285464", "light {path} must not be canonical steel-blue");
+  }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -269,6 +269,24 @@ pub fn warp_color(src: &str, key: &str) -> String {
   )
 }
 
+/// Read a hex color from an Alacritty TOML theme by dotted path.
+/// Example: `alacritty_color(src, "colors.primary.background")`.
+pub fn alacritty_color(src: &str, path: &str) -> String {
+  let table: toml::Table = src.parse().expect("invalid TOML");
+  let mut value: toml::Value = toml::Value::Table(table);
+  for part in path.split('.') {
+    value = value
+      .get(part)
+      .cloned()
+      .unwrap_or_else(|| panic!("missing path segment '{part}' in '{path}'"));
+  }
+  hex_to_lower(
+    value
+      .as_str()
+      .unwrap_or_else(|| panic!("path '{path}' is not a string")),
+  )
+}
+
 /// Extract an ANSI color from a Warp theme YAML file.
 /// `bank` is `"normal"` or `"bright"`. `name` is one of `black, red, green, yellow, blue, magenta, cyan, white`.
 pub fn warp_ansi_color(src: &str, bank: &str, name: &str) -> String {


### PR DESCRIPTION
This PR adds a port of the theme for the [alacritty](https://github.com/alacritty/alacritty) terminal emulator. It was modeled after the main spec and then compared with the various other terminal themes already present in this repo. A couple values did need slight tweaks for usability but all tests pass for the new theme. Claude did help write the agent and readme files for the `alacritty` theme and verify conformity and consistency across the other terminal emulators. Note, `alacritty` doesn't have an automatic light or dark mode which is why two themes were shipped instead of one.