### PR TITLE
Add WezTerm theme support

### DIFF
--- a/.github/workflows/release-themes.yml
+++ b/.github/workflows/release-themes.yml
@@ -124,6 +124,13 @@ jobs:
             warm-burnout-dark.yaml \
             warm-burnout-light.yaml
 
+      - name: Package WezTerm
+        run: |
+          cd wezterm
+          zip -j ../warm-burnout-wezterm.zip \
+            warm-burnout-dark.toml \
+            warm-burnout-light.toml
+
       - name: Package Alacritty
         run: |
           cd alacritty
@@ -201,6 +208,7 @@ jobs:
             warm-burnout-iterm2.zip
             warm-burnout-windows-terminal.zip
             warm-burnout-warp.zip
+            warm-burnout-wezterm.zip
             warm-burnout-alacritty.zip
             warm-burnout-tmux.zip
             warm-burnout-zellij.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ warm-burnout/
     jetbrains.rs              # JetBrains theme validation tests
     windows_terminal.rs       # Windows Terminal theme validation tests
     warp.rs                   # Warp theme validation tests
+    wezterm.rs                # WezTerm theme validation tests
     alacritty.rs              # Alacritty theme validation tests
     tmux.rs                   # tmux theme validation tests
     zellij.rs                 # Zellij theme validation tests
@@ -149,6 +150,11 @@ warm-burnout/
     AGENTS.md                 # Warp-specific agent rules
     warm-burnout-dark.yaml    # Dark variant
     warm-burnout-light.yaml   # Light variant
+  wezterm/                    # WezTerm terminal theme
+    README.md                 # WezTerm install instructions
+    AGENTS.md                 # WezTerm-specific agent rules
+    warm-burnout-dark.toml    # Dark variant (TOML color scheme)
+    warm-burnout-light.toml   # Light variant
   alacritty/                  # Alacritty terminal theme
     README.md                 # Alacritty install instructions
     AGENTS.md                 # Alacritty-specific agent rules

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Inspired by materials that age well. Unlike your eyes.
 | iTerm2 | Available | [`iterm2/`](iterm2/) |
 | Windows Terminal | Available | [`windows-terminal/`](windows-terminal/) |
 | Warp | Available | [`warp/`](warp/) |
+| WezTerm | Available | [`wezterm/`](wezterm/) |
 | Alacritty | Available | [`alacritty/`](alacritty/) |
 | tmux | Available | [`tmux/`](tmux/) |
 | Zellij | Available | [`zellij/`](zellij/) |

--- a/site/index.html
+++ b/site/index.html
@@ -453,6 +453,12 @@
             <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
           </a>
 
+          <a href="https://github.com/felipefdl/warm-burnout/tree/main/wezterm" class="retro-card rounded-md p-4 no-underline block">
+            <p class="text-sm font-bold theme-fg">WezTerm</p>
+            <p class="text-xs theme-fg-muted mt-1">Terminal</p>
+            <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
+          </a>
+
           <a href="https://github.com/felipefdl/warm-burnout/tree/main/alacritty" class="retro-card rounded-md p-4 no-underline block">
             <p class="text-sm font-bold theme-fg">Alacritty</p>
             <p class="text-xs theme-fg-muted mt-1">Terminal</p>

--- a/tests/brand.rs
+++ b/tests/brand.rs
@@ -16,6 +16,7 @@ const READMES: &[(&str, &str)] = &[
   ("emacs", include_str!("../emacs/README.md")),
   ("helix", include_str!("../helix/README.md")),
   ("bat", include_str!("../bat/README.md")),
+  ("wezterm", include_str!("../wezterm/README.md")),
 ];
 
 #[test]
@@ -46,6 +47,8 @@ fn no_theme_file_uses_patina_as_label() {
     ("zellij/light", include_str!("../zellij/warm-burnout-light.kdl")),
     ("warp/dark", include_str!("../warp/warm-burnout-dark.yaml")),
     ("warp/light", include_str!("../warp/warm-burnout-light.yaml")),
+    ("wezterm/dark", include_str!("../wezterm/warm-burnout-dark.toml")),
+    ("wezterm/light", include_str!("../wezterm/warm-burnout-light.toml")),
     ("iterm2/dark", include_str!("../iterm2/Warm Burnout Dark.itermcolors")),
     ("iterm2/light", include_str!("../iterm2/Warm Burnout Light.itermcolors")),
     ("jetbrains/dark", include_str!("../jetbrains/Warm-Burnout-Dark.xml")),

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -4,8 +4,8 @@ use common::{
   alacritty_color, bat_tmtheme_global_setting, emacs_palette_color, ghostty_ansi_color, ghostty_color,
   helix_palette_color, hex_to_lower, home_assistant_color, iterm2_color, jetbrains_attribute, jetbrains_color,
   nvim_palette_color, obsidian_color, starship_palette_color, tmux_option_value, tmux_style_bg, tmux_style_fg,
-  vscode_color, warp_ansi_color, warp_color, windows_terminal_color, xcode_color, xcode_syntax_color, zed_editor_color,
-  zellij_color,
+  vscode_color, warp_ansi_color, warp_color, wezterm_ansi_color, wezterm_color, windows_terminal_color, xcode_color,
+  xcode_syntax_color, zed_editor_color, zellij_color,
 };
 
 fn zsh_foreground(src: &str) -> Option<String> {
@@ -1110,6 +1110,286 @@ fn light_foreground_bat_matches_ghostty() {
   let bat = bat_tmtheme_global_setting(BAT_LIGHT, "foreground");
   let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-light"), "foreground");
   assert_eq!(bat, ghostty, "light foreground: bat={bat} ghostty={ghostty}");
+}
+
+// -- WezTerm cross-platform consistency --
+
+const WEZTERM_DARK: &str = include_str!("../wezterm/warm-burnout-dark.toml");
+const WEZTERM_LIGHT: &str = include_str!("../wezterm/warm-burnout-light.toml");
+
+#[test]
+fn dark_background_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_DARK, "colors.background");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-dark"), "background");
+  assert_eq!(wezterm, ghostty, "dark background: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn light_background_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_LIGHT, "colors.background");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-light"), "background");
+  assert_eq!(
+    wezterm, ghostty,
+    "light background: wezterm={wezterm} ghostty={ghostty}"
+  );
+}
+
+#[test]
+fn dark_foreground_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_DARK, "colors.foreground");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-dark"), "foreground");
+  assert_eq!(wezterm, ghostty, "dark foreground: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn light_foreground_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_LIGHT, "colors.foreground");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-light"), "foreground");
+  assert_eq!(
+    wezterm, ghostty,
+    "light foreground: wezterm={wezterm} ghostty={ghostty}"
+  );
+}
+
+#[test]
+fn dark_cursor_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_DARK, "colors.cursor_bg");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-dark"), "cursor-color");
+  assert_eq!(wezterm, ghostty, "dark cursor: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn light_cursor_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_LIGHT, "colors.cursor_bg");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-light"), "cursor-color");
+  assert_eq!(wezterm, ghostty, "light cursor: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn dark_selection_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_DARK, "colors.selection_bg");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-dark"), "selection-background");
+  assert_eq!(wezterm, ghostty, "dark selection: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn light_selection_wezterm_matches_ghostty() {
+  let wezterm = wezterm_color(WEZTERM_LIGHT, "colors.selection_bg");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-light"), "selection-background");
+  assert_eq!(wezterm, ghostty, "light selection: wezterm={wezterm} ghostty={ghostty}");
+}
+
+fn assert_wezterm_bank_matches_ghostty(wezterm_src: &str, ghostty_src: &str, bank: &str, base: u8, variant: &str) {
+  for index in 0..8 {
+    let wezterm = wezterm_ansi_color(wezterm_src, bank, index);
+    let ghostty = ghostty_ansi_color(ghostty_src, base + index as u8);
+    assert_eq!(
+      wezterm,
+      ghostty,
+      "{variant} {bank}[{index}] (palette {}): wezterm={wezterm} ghostty={ghostty}",
+      base + index as u8
+    );
+  }
+}
+
+#[test]
+fn dark_ansi_wezterm_matches_ghostty() {
+  assert_wezterm_bank_matches_ghostty(
+    WEZTERM_DARK,
+    include_str!("../ghostty/warm-burnout-dark"),
+    "ansi",
+    0,
+    "dark",
+  );
+}
+
+#[test]
+fn dark_brights_wezterm_matches_ghostty() {
+  assert_wezterm_bank_matches_ghostty(
+    WEZTERM_DARK,
+    include_str!("../ghostty/warm-burnout-dark"),
+    "brights",
+    8,
+    "dark",
+  );
+}
+
+#[test]
+fn light_ansi_wezterm_matches_ghostty() {
+  assert_wezterm_bank_matches_ghostty(
+    WEZTERM_LIGHT,
+    include_str!("../ghostty/warm-burnout-light"),
+    "ansi",
+    0,
+    "light",
+  );
+}
+
+#[test]
+fn light_brights_wezterm_matches_ghostty() {
+  assert_wezterm_bank_matches_ghostty(
+    WEZTERM_LIGHT,
+    include_str!("../ghostty/warm-burnout-light"),
+    "brights",
+    8,
+    "light",
+  );
+}
+
+#[test]
+fn dark_wezterm_active_tab_matches_tmux_and_zellij() {
+  let wezterm_tab = wezterm_color(WEZTERM_DARK, "colors.tab_bar.active_tab.bg_color");
+  let tmux_active = tmux_option_value(
+    include_str!("../tmux/warm-burnout-dark.conf"),
+    "window-status-current-style",
+  );
+  let tmux_bg = tmux_style_bg(&tmux_active);
+  let zellij_ribbon = zellij_color(
+    include_str!("../zellij/warm-burnout-dark.kdl"),
+    "warm-burnout-dark",
+    "ribbon_selected",
+    "background",
+  );
+  assert_eq!(
+    wezterm_tab, tmux_bg,
+    "dark WezTerm active tab should match tmux active window"
+  );
+  assert_eq!(
+    wezterm_tab, zellij_ribbon,
+    "dark WezTerm active tab should match Zellij active ribbon"
+  );
+}
+
+#[test]
+fn light_wezterm_active_tab_matches_tmux_and_zellij() {
+  let wezterm_tab = wezterm_color(WEZTERM_LIGHT, "colors.tab_bar.active_tab.bg_color");
+  let tmux_active = tmux_option_value(
+    include_str!("../tmux/warm-burnout-light.conf"),
+    "window-status-current-style",
+  );
+  let tmux_bg = tmux_style_bg(&tmux_active);
+  let zellij_ribbon = zellij_color(
+    include_str!("../zellij/warm-burnout-light.kdl"),
+    "warm-burnout-light",
+    "ribbon_selected",
+    "background",
+  );
+  assert_eq!(
+    wezterm_tab, tmux_bg,
+    "light WezTerm active tab should match tmux active window"
+  );
+  assert_eq!(
+    wezterm_tab, zellij_ribbon,
+    "light WezTerm active tab should match Zellij active ribbon"
+  );
+}
+
+#[test]
+fn dark_wezterm_split_matches_tmux_and_zellij_focus() {
+  let wezterm_split = wezterm_color(WEZTERM_DARK, "colors.split");
+  let tmux_border = tmux_option_value(
+    include_str!("../tmux/warm-burnout-dark.conf"),
+    "pane-active-border-style",
+  );
+  let tmux_fg = tmux_style_fg(&tmux_border);
+  let zellij_frame = zellij_color(
+    include_str!("../zellij/warm-burnout-dark.kdl"),
+    "warm-burnout-dark",
+    "frame_selected",
+    "base",
+  );
+  assert_eq!(
+    wezterm_split, tmux_fg,
+    "dark WezTerm split should match tmux active pane border"
+  );
+  assert_eq!(
+    wezterm_split, zellij_frame,
+    "dark WezTerm split should match Zellij focused frame"
+  );
+}
+
+#[test]
+fn light_wezterm_split_matches_tmux_and_zellij_focus() {
+  let wezterm_split = wezterm_color(WEZTERM_LIGHT, "colors.split");
+  let tmux_border = tmux_option_value(
+    include_str!("../tmux/warm-burnout-light.conf"),
+    "pane-active-border-style",
+  );
+  let tmux_fg = tmux_style_fg(&tmux_border);
+  let zellij_frame = zellij_color(
+    include_str!("../zellij/warm-burnout-light.kdl"),
+    "warm-burnout-light",
+    "frame_selected",
+    "base",
+  );
+  assert_eq!(
+    wezterm_split, tmux_fg,
+    "light WezTerm split should match tmux active pane border"
+  );
+  assert_eq!(
+    wezterm_split, zellij_frame,
+    "light WezTerm split should match Zellij focused frame"
+  );
+}
+
+#[test]
+fn dark_wezterm_inactive_tab_matches_zellij_raised_surface() {
+  let wezterm_tab = wezterm_color(WEZTERM_DARK, "colors.tab_bar.inactive_tab.bg_color");
+  let zellij_ribbon = zellij_color(
+    include_str!("../zellij/warm-burnout-dark.kdl"),
+    "warm-burnout-dark",
+    "ribbon_unselected",
+    "background",
+  );
+  assert_eq!(
+    wezterm_tab, zellij_ribbon,
+    "dark WezTerm inactive tab should match Zellij raised ribbon"
+  );
+}
+
+#[test]
+fn light_wezterm_inactive_tab_matches_zellij_raised_surface() {
+  let wezterm_tab = wezterm_color(WEZTERM_LIGHT, "colors.tab_bar.inactive_tab.bg_color");
+  let zellij_ribbon = zellij_color(
+    include_str!("../zellij/warm-burnout-light.kdl"),
+    "warm-burnout-light",
+    "ribbon_unselected",
+    "background",
+  );
+  assert_eq!(
+    wezterm_tab, zellij_ribbon,
+    "light WezTerm inactive tab should match Zellij raised ribbon"
+  );
+}
+
+#[test]
+fn dark_wezterm_scrollbar_matches_zellij_unfocused_frame() {
+  let wezterm_scrollbar = wezterm_color(WEZTERM_DARK, "colors.scrollbar_thumb");
+  let zellij_frame = zellij_color(
+    include_str!("../zellij/warm-burnout-dark.kdl"),
+    "warm-burnout-dark",
+    "frame_unselected",
+    "base",
+  );
+  assert_eq!(
+    wezterm_scrollbar, zellij_frame,
+    "dark WezTerm scrollbar should match Zellij unfocused frame"
+  );
+}
+
+#[test]
+fn light_wezterm_scrollbar_matches_zellij_unfocused_frame() {
+  let wezterm_scrollbar = wezterm_color(WEZTERM_LIGHT, "colors.scrollbar_thumb");
+  let zellij_frame = zellij_color(
+    include_str!("../zellij/warm-burnout-light.kdl"),
+    "warm-burnout-light",
+    "frame_unselected",
+    "base",
+  );
+  assert_eq!(
+    wezterm_scrollbar, zellij_frame,
+    "light WezTerm scrollbar should match Zellij unfocused frame"
+  );
 }
 
 // -- Home Assistant cross-platform consistency --

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -379,6 +379,51 @@ pub fn alacritty_color(src: &str, path: &str) -> String {
   )
 }
 
+/// Read a color/string value from a WezTerm TOML theme by dotted path.
+/// Example: `wezterm_color(src, "colors.background")`.
+pub fn wezterm_color(src: &str, path: &str) -> String {
+  let table: toml::Table = src.parse().expect("invalid TOML");
+  let mut value: toml::Value = toml::Value::Table(table);
+  for part in path.split('.') {
+    value = value
+      .get(part)
+      .cloned()
+      .unwrap_or_else(|| panic!("missing path segment '{part}' in '{path}'"));
+  }
+  let value = value.as_str().or_else(|| {
+    value
+      .as_table()
+      .and_then(|table| table.get("Color"))
+      .and_then(|color| color.as_str())
+  });
+  let value = value.unwrap_or_else(|| panic!("path '{path}' is not a string or Color table"));
+  if value.starts_with('#') {
+    hex_to_lower(value)
+  } else {
+    value.to_string()
+  }
+}
+
+/// Extract an ANSI color from a WezTerm `ansi` or `brights` array.
+pub fn wezterm_ansi_color(src: &str, bank: &str, index: usize) -> String {
+  let table: toml::Table = src.parse().expect("invalid TOML");
+  let colors = table
+    .get("colors")
+    .and_then(|v| v.as_table())
+    .expect("missing colors table");
+  let array = colors
+    .get(bank)
+    .and_then(|v| v.as_array())
+    .unwrap_or_else(|| panic!("missing colors.{bank} array"));
+  assert_eq!(array.len(), 8, "colors.{bank} must contain exactly 8 entries");
+  hex_to_lower(
+    array
+      .get(index)
+      .and_then(|v| v.as_str())
+      .unwrap_or_else(|| panic!("missing colors.{bank}[{index}]")),
+  )
+}
+
 /// Extract an ANSI color from a Warp theme YAML file.
 /// `bank` is `"normal"` or `"bright"`. `name` is one of `black, red, green, yellow, blue, magenta, cyan, white`.
 pub fn warp_ansi_color(src: &str, bank: &str, name: &str) -> String {

--- a/tests/wezterm.rs
+++ b/tests/wezterm.rs
@@ -1,0 +1,384 @@
+mod common;
+
+use common::{extract_hex_colors, ghostty_ansi_color, ghostty_color, is_valid_hex, wezterm_ansi_color, wezterm_color};
+
+const DARK: &str = include_str!("../wezterm/warm-burnout-dark.toml");
+const LIGHT: &str = include_str!("../wezterm/warm-burnout-light.toml");
+
+const GHOSTTY_DARK: &str = include_str!("../ghostty/warm-burnout-dark");
+const GHOSTTY_LIGHT: &str = include_str!("../ghostty/warm-burnout-light");
+
+const REQUIRED_TABLES: &[&str] = &[
+  "colors",
+  "colors.indexed",
+  "colors.tab_bar",
+  "colors.tab_bar.active_tab",
+  "colors.tab_bar.inactive_tab",
+  "colors.tab_bar.inactive_tab_hover",
+  "colors.tab_bar.new_tab",
+  "colors.tab_bar.new_tab_hover",
+  "metadata",
+];
+
+const UNSUPPORTED_STABLE_PALETTE_KEYS: &[&str] = &[
+  "input_selector_label_bg",
+  "input_selector_label_fg",
+  "launcher_label_bg",
+  "launcher_label_fg",
+];
+
+fn parse_toml(src: &str) -> toml::Table {
+  src.parse::<toml::Table>().expect("invalid TOML")
+}
+
+fn assert_path_exists(src: &str, path: &str, variant: &str) {
+  let table = parse_toml(src);
+  let mut value = toml::Value::Table(table);
+  for part in path.split('.') {
+    value = match value.get(part) {
+      Some(v) => v.clone(),
+      None => panic!("{variant}: missing required table path '{path}' (failed at '{part}')"),
+    };
+  }
+  assert!(value.is_table(), "{variant}: '{path}' exists but is not a table");
+}
+
+fn assert_unsupported_stable_palette_keys_absent(src: &str, variant: &str) {
+  let table = parse_toml(src);
+  let colors = table
+    .get("colors")
+    .and_then(|v| v.as_table())
+    .expect("missing colors table");
+  for key in UNSUPPORTED_STABLE_PALETTE_KEYS {
+    assert!(
+      !colors.contains_key(*key),
+      "{variant}: colors.{key} is not accepted by stable WezTerm palette files"
+    );
+  }
+}
+
+#[test]
+fn dark_is_valid_toml() {
+  parse_toml(DARK);
+}
+
+#[test]
+fn light_is_valid_toml() {
+  parse_toml(LIGHT);
+}
+
+#[test]
+fn dark_all_hex_colors_are_valid() {
+  for (line, hex) in extract_hex_colors(DARK) {
+    assert!(is_valid_hex(hex), "dark line {line}: invalid hex: {hex}");
+  }
+}
+
+#[test]
+fn light_all_hex_colors_are_valid() {
+  for (line, hex) in extract_hex_colors(LIGHT) {
+    assert!(is_valid_hex(hex), "light line {line}: invalid hex: {hex}");
+  }
+}
+
+#[test]
+fn dark_has_required_tables() {
+  for path in REQUIRED_TABLES {
+    assert_path_exists(DARK, path, "dark");
+  }
+}
+
+#[test]
+fn light_has_required_tables() {
+  for path in REQUIRED_TABLES {
+    assert_path_exists(LIGHT, path, "light");
+  }
+}
+
+#[test]
+fn dark_has_no_unsupported_stable_palette_keys() {
+  assert_unsupported_stable_palette_keys_absent(DARK, "dark");
+}
+
+#[test]
+fn light_has_no_unsupported_stable_palette_keys() {
+  assert_unsupported_stable_palette_keys_absent(LIGHT, "light");
+}
+
+#[test]
+fn dark_metadata_name_is_warm_burnout_dark() {
+  assert_eq!(wezterm_color(DARK, "metadata.name"), "Warm Burnout Dark");
+}
+
+#[test]
+fn light_metadata_name_is_warm_burnout_light() {
+  assert_eq!(wezterm_color(LIGHT, "metadata.name"), "Warm Burnout Light");
+}
+
+#[test]
+fn dark_background_matches_ghostty() {
+  let wezterm = wezterm_color(DARK, "colors.background");
+  let ghostty = ghostty_color(GHOSTTY_DARK, "background");
+  assert_eq!(wezterm, ghostty, "dark background: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn light_background_matches_ghostty() {
+  let wezterm = wezterm_color(LIGHT, "colors.background");
+  let ghostty = ghostty_color(GHOSTTY_LIGHT, "background");
+  assert_eq!(
+    wezterm, ghostty,
+    "light background: wezterm={wezterm} ghostty={ghostty}"
+  );
+}
+
+#[test]
+fn dark_foreground_matches_ghostty() {
+  let wezterm = wezterm_color(DARK, "colors.foreground");
+  let ghostty = ghostty_color(GHOSTTY_DARK, "foreground");
+  assert_eq!(wezterm, ghostty, "dark foreground: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn light_foreground_matches_ghostty() {
+  let wezterm = wezterm_color(LIGHT, "colors.foreground");
+  let ghostty = ghostty_color(GHOSTTY_LIGHT, "foreground");
+  assert_eq!(
+    wezterm, ghostty,
+    "light foreground: wezterm={wezterm} ghostty={ghostty}"
+  );
+}
+
+#[test]
+fn dark_cursor_matches_ghostty() {
+  let wezterm = wezterm_color(DARK, "colors.cursor_bg");
+  let ghostty = ghostty_color(GHOSTTY_DARK, "cursor-color");
+  assert_eq!(wezterm, ghostty, "dark cursor: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn light_cursor_matches_ghostty() {
+  let wezterm = wezterm_color(LIGHT, "colors.cursor_bg");
+  let ghostty = ghostty_color(GHOSTTY_LIGHT, "cursor-color");
+  assert_eq!(wezterm, ghostty, "light cursor: wezterm={wezterm} ghostty={ghostty}");
+}
+
+#[test]
+fn dark_cursor_fg_matches_background() {
+  assert_eq!(
+    wezterm_color(DARK, "colors.cursor_fg"),
+    wezterm_color(DARK, "colors.background")
+  );
+}
+
+#[test]
+fn light_cursor_fg_matches_background() {
+  assert_eq!(
+    wezterm_color(LIGHT, "colors.cursor_fg"),
+    wezterm_color(LIGHT, "colors.background")
+  );
+}
+
+#[test]
+fn dark_selection_matches_ghostty() {
+  assert_eq!(
+    wezterm_color(DARK, "colors.selection_bg"),
+    ghostty_color(GHOSTTY_DARK, "selection-background")
+  );
+  assert_eq!(
+    wezterm_color(DARK, "colors.selection_fg"),
+    ghostty_color(GHOSTTY_DARK, "selection-foreground")
+  );
+}
+
+#[test]
+fn light_selection_matches_ghostty() {
+  assert_eq!(
+    wezterm_color(LIGHT, "colors.selection_bg"),
+    ghostty_color(GHOSTTY_LIGHT, "selection-background")
+  );
+  assert_eq!(
+    wezterm_color(LIGHT, "colors.selection_fg"),
+    ghostty_color(GHOSTTY_LIGHT, "selection-foreground")
+  );
+}
+
+fn assert_ansi_bank_matches_ghostty(wezterm_src: &str, ghostty_src: &str, bank: &str, base: u8, variant: &str) {
+  for index in 0..8 {
+    let wezterm = wezterm_ansi_color(wezterm_src, bank, index);
+    let ghostty = ghostty_ansi_color(ghostty_src, base + index as u8);
+    assert_eq!(
+      wezterm,
+      ghostty,
+      "{variant} {bank}[{index}] (palette {}): wezterm={wezterm} ghostty={ghostty}",
+      base + index as u8
+    );
+  }
+}
+
+#[test]
+fn dark_ansi_matches_ghostty() {
+  assert_ansi_bank_matches_ghostty(DARK, GHOSTTY_DARK, "ansi", 0, "dark");
+}
+
+#[test]
+fn dark_brights_match_ghostty() {
+  assert_ansi_bank_matches_ghostty(DARK, GHOSTTY_DARK, "brights", 8, "dark");
+}
+
+#[test]
+fn light_ansi_matches_ghostty() {
+  assert_ansi_bank_matches_ghostty(LIGHT, GHOSTTY_LIGHT, "ansi", 0, "light");
+}
+
+#[test]
+fn light_brights_match_ghostty() {
+  assert_ansi_bank_matches_ghostty(LIGHT, GHOSTTY_LIGHT, "brights", 8, "light");
+}
+
+#[test]
+fn dark_split_uses_canonical_accent() {
+  assert_eq!(wezterm_color(DARK, "colors.split"), "#b8522e");
+}
+
+#[test]
+fn light_split_uses_canonical_accent() {
+  assert_eq!(wezterm_color(LIGHT, "colors.split"), "#b8522e");
+}
+
+#[test]
+fn dark_scrollbar_uses_unfocused_frame_stone() {
+  assert_eq!(wezterm_color(DARK, "colors.scrollbar_thumb"), "#3a342a");
+}
+
+#[test]
+fn light_scrollbar_uses_unfocused_frame_stone() {
+  assert_eq!(wezterm_color(LIGHT, "colors.scrollbar_thumb"), "#c5beb2");
+}
+
+#[test]
+fn dark_compose_cursor_matches_cursor_and_bell_uses_amber() {
+  assert_eq!(
+    wezterm_color(DARK, "colors.compose_cursor"),
+    wezterm_color(DARK, "colors.cursor_bg")
+  );
+  assert_eq!(wezterm_color(DARK, "colors.visual_bell"), "#ffb454");
+}
+
+#[test]
+fn light_compose_cursor_matches_cursor_and_bell_uses_amber() {
+  assert_eq!(
+    wezterm_color(LIGHT, "colors.compose_cursor"),
+    wezterm_color(LIGHT, "colors.cursor_bg")
+  );
+  assert_eq!(wezterm_color(LIGHT, "colors.visual_bell"), "#855700");
+}
+
+#[test]
+fn dark_active_tab_uses_keywords_token() {
+  assert_eq!(wezterm_color(DARK, "colors.tab_bar.active_tab.bg_color"), "#ff8f40");
+  assert_eq!(wezterm_color(DARK, "colors.tab_bar.active_tab.fg_color"), "#1a1510");
+}
+
+#[test]
+fn light_active_tab_uses_keywords_token() {
+  assert_eq!(wezterm_color(LIGHT, "colors.tab_bar.active_tab.bg_color"), "#924800");
+  assert_eq!(wezterm_color(LIGHT, "colors.tab_bar.active_tab.fg_color"), "#f5ede0");
+}
+
+#[test]
+fn dark_tab_bar_background_matches_terminal_background() {
+  assert_eq!(
+    wezterm_color(DARK, "colors.tab_bar.background"),
+    wezterm_color(DARK, "colors.background")
+  );
+}
+
+#[test]
+fn light_tab_bar_background_matches_terminal_background() {
+  assert_eq!(
+    wezterm_color(LIGHT, "colors.tab_bar.background"),
+    wezterm_color(LIGHT, "colors.background")
+  );
+}
+
+#[test]
+fn dark_inactive_tabs_use_raised_surface_and_comments() {
+  assert_eq!(wezterm_color(DARK, "colors.tab_bar.inactive_tab.bg_color"), "#1f1d17");
+  assert_eq!(wezterm_color(DARK, "colors.tab_bar.inactive_tab.fg_color"), "#b4a89c");
+  assert_eq!(wezterm_color(DARK, "colors.tab_bar.new_tab.bg_color"), "#1f1d17");
+  assert_eq!(wezterm_color(DARK, "colors.tab_bar.new_tab.fg_color"), "#b4a89c");
+}
+
+#[test]
+fn light_inactive_tabs_use_raised_surface_and_comments() {
+  assert_eq!(wezterm_color(LIGHT, "colors.tab_bar.inactive_tab.bg_color"), "#f0e8dc");
+  assert_eq!(wezterm_color(LIGHT, "colors.tab_bar.inactive_tab.fg_color"), "#544c40");
+  assert_eq!(wezterm_color(LIGHT, "colors.tab_bar.new_tab.bg_color"), "#f0e8dc");
+  assert_eq!(wezterm_color(LIGHT, "colors.tab_bar.new_tab.fg_color"), "#544c40");
+}
+
+#[test]
+fn dark_copy_and_quick_select_use_terminal_ui_roles() {
+  assert_eq!(wezterm_color(DARK, "colors.copy_mode_active_highlight_bg"), "#ff8f40");
+  assert_eq!(wezterm_color(DARK, "colors.copy_mode_inactive_highlight_bg"), "#33393a");
+  assert_eq!(wezterm_color(DARK, "colors.quick_select_label_bg"), "#ffb454");
+  assert_eq!(wezterm_color(DARK, "colors.quick_select_match_bg"), "#33393a");
+}
+
+#[test]
+fn light_copy_and_quick_select_use_terminal_ui_roles() {
+  assert_eq!(wezterm_color(LIGHT, "colors.copy_mode_active_highlight_bg"), "#924800");
+  assert_eq!(
+    wezterm_color(LIGHT, "colors.copy_mode_inactive_highlight_bg"),
+    "#e5e8e2"
+  );
+  assert_eq!(wezterm_color(LIGHT, "colors.quick_select_label_bg"), "#855700");
+  assert_eq!(wezterm_color(LIGHT, "colors.quick_select_match_bg"), "#e5e8e2");
+}
+
+#[test]
+fn dark_indexed_palette_exposes_accent_and_amber() {
+  assert_eq!(wezterm_color(DARK, "colors.indexed.16"), "#b8522e");
+  assert_eq!(wezterm_color(DARK, "colors.indexed.17"), "#ffb454");
+}
+
+#[test]
+fn light_indexed_palette_exposes_accent_and_amber() {
+  assert_eq!(wezterm_color(LIGHT, "colors.indexed.16"), "#b8522e");
+  assert_eq!(wezterm_color(LIGHT, "colors.indexed.17"), "#855700");
+}
+
+#[test]
+fn dark_no_canonical_steel_blue_in_chrome() {
+  for path in [
+    "colors.foreground",
+    "colors.background",
+    "colors.cursor_bg",
+    "colors.selection_bg",
+    "colors.split",
+    "colors.scrollbar_thumb",
+    "colors.tab_bar.active_tab.bg_color",
+    "colors.tab_bar.inactive_tab.bg_color",
+  ] {
+    let value = wezterm_color(DARK, path);
+    assert_ne!(value, "#90aec0", "dark {path} must not be canonical steel-blue");
+  }
+}
+
+#[test]
+fn light_no_canonical_steel_blue_in_chrome() {
+  for path in [
+    "colors.foreground",
+    "colors.background",
+    "colors.cursor_bg",
+    "colors.selection_bg",
+    "colors.split",
+    "colors.scrollbar_thumb",
+    "colors.tab_bar.active_tab.bg_color",
+    "colors.tab_bar.inactive_tab.bg_color",
+  ] {
+    let value = wezterm_color(LIGHT, path);
+    assert_ne!(value, "#285464", "light {path} must not be canonical steel-blue");
+  }
+}

--- a/wezterm/AGENTS.md
+++ b/wezterm/AGENTS.md
@@ -18,7 +18,9 @@ WezTerm standalone color schemes are TOML files with `[colors]` and `[metadata]`
 | `colors.selection_bg` / `selection_fg` | Ghostty selection background and foreground |
 | `colors.ansi` | Ghostty `palette = 0` through `palette = 7` |
 | `colors.brights` | Ghostty `palette = 8` through `palette = 15` |
+| `colors.scrollbar_thumb` / `tab_bar.inactive_tab_edge` | Zellij `frame_unselected.base` stone (`#3a342a` dark, `#c5beb2` light) |
 | `colors.split` | Canonical copper rust accent (`#b8522e`) |
+| `colors.tab_bar.background` | Mirrors `colors.background` so the tab bar reads as part of the terminal |
 | `colors.tab_bar.active_tab.bg_color` | Keywords token (`#ff8f40` dark, `#924800` light) |
 
 The `ansi` and `brights` arrays must stay in conventional terminal order: black, red, green, yellow, blue, magenta, cyan, white.

--- a/wezterm/AGENTS.md
+++ b/wezterm/AGENTS.md
@@ -1,0 +1,37 @@
+# WezTerm Agent Instructions
+
+Follow the root [`AGENTS.md`](../AGENTS.md). The canonical palette lives there; do not duplicate the palette tables here.
+
+## Format
+
+WezTerm standalone color schemes are TOML files with `[colors]` and `[metadata]` sections. Place them in `~/.config/wezterm/colors`; WezTerm loads the display name from `metadata.name` when present.
+
+## Mapping
+
+| WezTerm Key | Canonical Source |
+|-------------|-----------------|
+| `metadata.name` | `Warm Burnout Dark` / `Warm Burnout Light` |
+| `colors.background` | Editor background (`#1a1510` dark, `#F5EDE0` light) |
+| `colors.foreground` | Editor foreground (`#bfbdb6` dark, `#3a3630` light) |
+| `colors.cursor_bg` / `cursor_border` | Canonical cursor (`#f5c56e` dark, `#8a6600` light) |
+| `colors.cursor_fg` | Background, so block cursor text stays readable |
+| `colors.selection_bg` / `selection_fg` | Ghostty selection background and foreground |
+| `colors.ansi` | Ghostty `palette = 0` through `palette = 7` |
+| `colors.brights` | Ghostty `palette = 8` through `palette = 15` |
+| `colors.split` | Canonical copper rust accent (`#b8522e`) |
+| `colors.tab_bar.active_tab.bg_color` | Keywords token (`#ff8f40` dark, `#924800` light) |
+
+The `ansi` and `brights` arrays must stay in conventional terminal order: black, red, green, yellow, blue, magenta, cyan, white.
+
+## Metadata
+
+Keep filenames lowercase and hyphenated:
+
+- Dark theme: `warm-burnout-dark.toml`
+- Light theme: `warm-burnout-light.toml`
+
+Keep `metadata.name` in title case so users select `Warm Burnout Dark` or `Warm Burnout Light` in `wezterm.lua`.
+
+## Chrome Discipline
+
+WezTerm themes can color native surfaces: tab bar, copy mode, quick select, split lines, and scrollbar thumb. Keep those warm. The steel-blue type accent is reserved for syntax and should not appear in WezTerm chrome. ANSI blue is exempt because terminal programs depend on that slot.

--- a/wezterm/README.md
+++ b/wezterm/README.md
@@ -50,7 +50,7 @@ WezTerm reloads config automatically. Use **Ctrl+Shift+R** if you enjoy pressing
 
 ## Verify
 
-Run `ls --color` or an ANSI color test script. Tabs should use burnt orange for the active tab, selection should stay muted, and splits should land on copper rust instead of default gray despair.
+Run `ls --color` or an ANSI color test script. Tabs should use burnt orange for the active tab, the cursor should land on amber gold (or oxidized brass on light), selection should stay muted, splits should land on copper rust instead of default gray despair, and copy mode (default `Ctrl+Shift+X`) should highlight the active match in the same burnt orange as the active tab.
 
 ## Palette
 

--- a/wezterm/README.md
+++ b/wezterm/README.md
@@ -1,0 +1,57 @@
+# Warm Burnout for WezTerm
+
+The GPU terminal gets a calibrated dose too. Your eyes deserved this.
+
+## Install
+
+Drop the TOML files into WezTerm's color scheme directory:
+
+```sh
+mkdir -p ~/.config/wezterm/colors
+cp warm-burnout-dark.toml warm-burnout-light.toml ~/.config/wezterm/colors/
+```
+
+Windows portable installs look for a `colors` directory beside `wezterm.exe`. For a custom location, set `color_scheme_dirs` in your `wezterm.lua`.
+
+## Configure
+
+Set the scheme in `~/.config/wezterm/wezterm.lua`:
+
+```lua
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+config.color_scheme = 'Warm Burnout Dark'
+
+return config
+```
+
+Swap to `Warm Burnout Light` when daylight wins.
+
+### Auto-switching
+
+```lua
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+local function scheme_for_appearance(appearance)
+  if appearance:find 'Dark' then
+    return 'Warm Burnout Dark'
+  end
+  return 'Warm Burnout Light'
+end
+
+config.color_scheme = scheme_for_appearance(wezterm.gui.get_appearance())
+
+return config
+```
+
+WezTerm reloads config automatically. Use **Ctrl+Shift+R** if you enjoy pressing the panic button politely.
+
+## Verify
+
+Run `ls --color` or an ANSI color test script. Tabs should use burnt orange for the active tab, selection should stay muted, and splits should land on copper rust instead of default gray despair.
+
+## Palette
+
+Both themes derive from the canonical Warm Burnout palette defined in the root [`AGENTS.md`](../AGENTS.md). The 16 ANSI colors and terminal background, foreground, cursor, and selection colors match the Ghostty theme exactly.

--- a/wezterm/warm-burnout-dark.toml
+++ b/wezterm/warm-burnout-dark.toml
@@ -1,0 +1,85 @@
+# Warm Burnout Dark
+
+[colors]
+foreground = "#bfbdb6"
+background = "#1a1510"
+
+cursor_bg = "#f5c56e"
+cursor_fg = "#1a1510"
+cursor_border = "#f5c56e"
+
+selection_fg = "#bfbdb6"
+selection_bg = "#33393a"
+
+scrollbar_thumb = "#3a342a"
+split = "#b8522e"
+visual_bell = "#ffb454"
+compose_cursor = "#f5c56e"
+
+ansi = [
+  "#23211b",
+  "#f06b73",
+  "#70bf56",
+  "#fdb04c",
+  "#4fbfff",
+  "#d0a1ff",
+  "#93e2c8",
+  "#c7c7c7",
+]
+
+brights = [
+  "#686868",
+  "#f07178",
+  "#aad94c",
+  "#ffb454",
+  "#59c2ff",
+  "#d2a6ff",
+  "#95e6cb",
+  "#ffffff",
+]
+
+copy_mode_active_highlight_bg = { Color = "#ff8f40" }
+copy_mode_active_highlight_fg = { Color = "#1a1510" }
+copy_mode_inactive_highlight_bg = { Color = "#33393a" }
+copy_mode_inactive_highlight_fg = { Color = "#bfbdb6" }
+
+quick_select_label_bg = { Color = "#ffb454" }
+quick_select_label_fg = { Color = "#1a1510" }
+quick_select_match_bg = { Color = "#33393a" }
+quick_select_match_fg = { Color = "#bfbdb6" }
+
+[colors.indexed]
+16 = "#b8522e"
+17 = "#ffb454"
+
+[colors.tab_bar]
+background = "#1a1510"
+inactive_tab_edge = "#3a342a"
+inactive_tab_edge_hover = "#b8522e"
+
+[colors.tab_bar.active_tab]
+bg_color = "#ff8f40"
+fg_color = "#1a1510"
+intensity = "Bold"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#1f1d17"
+fg_color = "#b4a89c"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#3a342a"
+fg_color = "#bfbdb6"
+italic = true
+
+[colors.tab_bar.new_tab]
+bg_color = "#1f1d17"
+fg_color = "#b4a89c"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#3a342a"
+fg_color = "#bfbdb6"
+italic = true
+
+[metadata]
+name = "Warm Burnout Dark"
+origin_url = "https://github.com/felipefdl/warm-burnout"

--- a/wezterm/warm-burnout-light.toml
+++ b/wezterm/warm-burnout-light.toml
@@ -1,0 +1,85 @@
+# Warm Burnout Light
+
+[colors]
+foreground = "#3a3630"
+background = "#f5ede0"
+
+cursor_bg = "#8a6600"
+cursor_fg = "#f5ede0"
+cursor_border = "#8a6600"
+
+selection_fg = "#3a3630"
+selection_bg = "#e5e8e2"
+
+scrollbar_thumb = "#c5beb2"
+split = "#b8522e"
+visual_bell = "#855700"
+compose_cursor = "#8a6600"
+
+ansi = [
+  "#3a3630",
+  "#b82820",
+  "#2d6a14",
+  "#8a6000",
+  "#2060a0",
+  "#8a3090",
+  "#146858",
+  "#c0b8aa",
+]
+
+brights = [
+  "#686868",
+  "#c83028",
+  "#3a7a20",
+  "#9a7008",
+  "#2870b0",
+  "#9a38a0",
+  "#208870",
+  "#faf6f0",
+]
+
+copy_mode_active_highlight_bg = { Color = "#924800" }
+copy_mode_active_highlight_fg = { Color = "#f5ede0" }
+copy_mode_inactive_highlight_bg = { Color = "#e5e8e2" }
+copy_mode_inactive_highlight_fg = { Color = "#3a3630" }
+
+quick_select_label_bg = { Color = "#855700" }
+quick_select_label_fg = { Color = "#f5ede0" }
+quick_select_match_bg = { Color = "#e5e8e2" }
+quick_select_match_fg = { Color = "#3a3630" }
+
+[colors.indexed]
+16 = "#b8522e"
+17 = "#855700"
+
+[colors.tab_bar]
+background = "#f5ede0"
+inactive_tab_edge = "#c5beb2"
+inactive_tab_edge_hover = "#b8522e"
+
+[colors.tab_bar.active_tab]
+bg_color = "#924800"
+fg_color = "#f5ede0"
+intensity = "Bold"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#f0e8dc"
+fg_color = "#544c40"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#ddd6ca"
+fg_color = "#3a3630"
+italic = true
+
+[colors.tab_bar.new_tab]
+bg_color = "#f0e8dc"
+fg_color = "#544c40"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#ddd6ca"
+fg_color = "#3a3630"
+italic = true
+
+[metadata]
+name = "Warm Burnout Light"
+origin_url = "https://github.com/felipefdl/warm-burnout"


### PR DESCRIPTION
## Summary

Adds Warm Burnout Dark and Light themes for WezTerm, with terminal colors aligned to the existing Ghostty palette and native WezTerm chrome mapped to the repo’s tmux and Zellij conventions.

## Changes

- Add standalone WezTerm TOML color schemes
- Add WezTerm install and configuration docs
- Package WezTerm themes in release artifacts
- Add WezTerm validation tests and cross-platform palette checks
- Update the root README, site platform grid, and agent instructions
