### PR TITLE
Add Bat theme support

### DIFF
--- a/.github/workflows/release-themes.yml
+++ b/.github/workflows/release-themes.yml
@@ -158,6 +158,13 @@ jobs:
             warm-burnout-dark.toml \
             warm-burnout-light.toml
 
+      - name: Package Bat
+        run: |
+          cd bat
+          zip -j ../warm-burnout-bat.zip \
+            "Warm Burnout Dark.tmTheme" \
+            "Warm Burnout Light.tmTheme"
+
       - name: Package Home Assistant
         run: cp themes/warm-burnout.yaml warm-burnout-home-assistant.yaml
 
@@ -199,6 +206,7 @@ jobs:
             warm-burnout-zellij.zip
             warm-burnout-eza.zip
             warm-burnout-helix.zip
+            warm-burnout-bat.zip
             warm-burnout-home-assistant.yaml
             warm-burnout-obsidian.zip
             warm-burnout-emacs.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ warm-burnout/
     zsh.rs                    # Zsh theme validation tests
     nvim.rs                   # Neovim theme validation tests
     vim.rs                    # Vim theme validation tests
+    bat.rs                    # Bat theme validation tests
     obsidian.rs               # Obsidian theme validation tests
     emacs.rs                  # Emacs theme validation tests
   .github/workflows/
@@ -169,6 +170,11 @@ warm-burnout/
     light.yml                 # Light variant
     README.md                 # eza install instructions
     AGENTS.md                 # eza-specific agent rules
+  bat/                        # Bat syntax highlighting theme
+    README.md                 # Bat install instructions
+    AGENTS.md                 # Bat-specific agent rules
+    Warm Burnout Dark.tmTheme # Dark variant (Sublime Text tmTheme)
+    Warm Burnout Light.tmTheme # Light variant (Sublime Text tmTheme)
   obsidian/                    # Obsidian community theme
     theme.css                  # Dark + light variants (CSS custom properties)
     manifest.json              # Community theme manifest

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Inspired by materials that age well. Unlike your eyes.
 | Neovim | Available | [`nvim/`](nvim/) |
 | Vim | Available | [`vim/`](vim/) |
 | Helix | Available | [`helix/`](helix/) |
+| Bat | Available | [`bat/`](bat/) |
 | Xcode | Available | [`xcode/`](xcode/) |
 | iTerm2 | Available | [`iterm2/`](iterm2/) |
 | Windows Terminal | Available | [`windows-terminal/`](windows-terminal/) |

--- a/bat/AGENTS.md
+++ b/bat/AGENTS.md
@@ -1,0 +1,47 @@
+# Bat -- Agent Instructions
+
+Follow the root [`AGENTS.md`](../AGENTS.md). The canonical palette lives there; do not duplicate the palette tables here.
+
+## Bat Theme Format
+
+- Bat custom themes must be Sublime Text `.tmTheme` XML plist files.
+- Newer `.sublime-color-scheme` files are not supported by Bat.
+- Users install themes into `$(bat --config-dir)/themes` and run `bat cache --build`.
+- Bat uses the `.tmTheme` filename as the theme name, so filenames must stay title-cased:
+  - `Warm Burnout Dark.tmTheme`
+  - `Warm Burnout Light.tmTheme`
+
+## Scope Mapping
+
+- TextMate scopes mirror the VS Code and Helix mappings where possible.
+- **bold** = keywords, storage scopes, and tags.
+- *italic* = comments, types/classes, decorators, CSS properties, and language built-ins where the platform supports it.
+- Normal = functions, strings, constants, operators, variables, and punctuation.
+
+## Color Rules
+
+1. Use exact hex values from the canonical palette. No approximations.
+2. Background and foreground must match Ghostty terminal base colors.
+3. Selection uses pre-blended opaque values: `#33393a` dark and `#e5e8e2` light.
+4. Line highlight uses pre-blended opaque values: `#222018` dark and `#e2dace` light.
+5. Do not use terminal ANSI colors here; Bat themes are truecolor syntax themes.
+6. Keep the steel-blue type accent limited to type/class scopes.
+
+## Testing
+
+Run:
+
+```sh
+cargo test --test bat
+cargo test --test canonical -- bat
+```
+
+If `bat` is installed, also validate with a temporary config dir:
+
+```sh
+tmp=$(mktemp -d)
+mkdir -p "$tmp/themes"
+cp bat/*.tmTheme "$tmp/themes/"
+BAT_CONFIG_DIR="$tmp" bat cache --build
+BAT_CONFIG_DIR="$tmp" bat --list-themes | grep 'Warm Burnout'
+```

--- a/bat/README.md
+++ b/bat/README.md
@@ -1,0 +1,54 @@
+# Warm Burnout for Bat
+
+Syntax-highlighted cat, now with warmer damage. Your terminal deserved a better autopsy light.
+
+## Install
+
+Copy the `.tmTheme` files into Bat's theme directory:
+
+```sh
+mkdir -p "$(bat --config-dir)/themes"
+cp "Warm Burnout Dark.tmTheme" "Warm Burnout Light.tmTheme" "$(bat --config-dir)/themes/"
+bat cache --build
+```
+
+Then use either theme:
+
+```sh
+bat --theme="Warm Burnout Dark" README.md
+bat --theme="Warm Burnout Light" README.md
+```
+
+To make it permanent, add one of these to your Bat config file:
+
+```sh
+--theme="Warm Burnout Dark"
+```
+
+Bat can also switch by terminal appearance:
+
+```sh
+--theme=auto:system
+--theme-dark="Warm Burnout Dark"
+--theme-light="Warm Burnout Light"
+```
+
+Find your config file path with:
+
+```sh
+bat --config-file
+```
+
+## Verify
+
+After rebuilding the cache, check that Bat can see the themes:
+
+```sh
+bat --list-themes | grep 'Warm Burnout'
+```
+
+If the names do not appear, rebuild the cache again. Bat likes a ritual. It is still less dramatic than your deadlines.
+
+## Palette
+
+Both themes derive from the canonical Warm Burnout palette in the root [`AGENTS.md`](../AGENTS.md). The scope mapping mirrors the editor themes where Bat's TextMate theme format allows it.

--- a/bat/Warm Burnout Dark.tmTheme
+++ b/bat/Warm Burnout Dark.tmTheme
@@ -177,7 +177,7 @@
       <key>name</key>
       <string>CSS Properties</string>
       <key>scope</key>
-      <string>support.type.property-name.css, meta.property-name.css, variable.css, entity.other.attribute-name.class.css, entity.other.attribute-name.id.css</string>
+      <string>support.type.property-name.css, meta.property-name.css, variable.css</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -201,7 +201,7 @@
       <key>name</key>
       <string>Parameters</string>
       <key>scope</key>
-      <string>variable.parameter, meta.parameters, punctuation.definition.parameters</string>
+      <string>variable.parameter</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>

--- a/bat/Warm Burnout Dark.tmTheme
+++ b/bat/Warm Burnout Dark.tmTheme
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Warm Burnout Dark</string>
+  <key>uuid</key>
+  <string>warm-burnout-dark</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#1a1510</string>
+        <key>foreground</key>
+        <string>#bfbdb6</string>
+        <key>caret</key>
+        <string>#f5c56e</string>
+        <key>selection</key>
+        <string>#33393a</string>
+        <key>lineHighlight</key>
+        <string>#222018</string>
+        <key>invisibles</key>
+        <string>#746f67</string>
+        <key>gutterForeground</key>
+        <string>#746f67</string>
+        <key>gutterBackground</key>
+        <string>#1a1510</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Comments</string>
+      <key>scope</key>
+      <string>comment, punctuation.definition.comment</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#b4a89c</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Strings</string>
+      <key>scope</key>
+      <string>string, punctuation.definition.string, string.quoted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#b4bc78</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Regular Expressions And Escapes</string>
+      <key>scope</key>
+      <string>string.regexp, constant.character.escape, constant.other.character-class, keyword.operator.quantifier.regexp</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#96b898</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constants And Numbers</string>
+      <key>scope</key>
+      <string>constant, constant.numeric, constant.language, constant.character, variable.other.constant</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#d4a8b8</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keywords</string>
+      <key>scope</key>
+      <string>keyword, keyword.control, keyword.other, storage, storage.modifier, storage.type</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ff8f40</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Operators</string>
+      <key>scope</key>
+      <string>keyword.operator, keyword.operator.assignment, keyword.operator.comparison, keyword.operator.logical, keyword.operator.arithmetic</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f29668</string>
+        <key>fontStyle</key>
+        <string></string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Functions</string>
+      <key>scope</key>
+      <string>entity.name.function, support.function, meta.function-call, variable.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ffb454</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Library Functions And Support</string>
+      <key>scope</key>
+      <string>support.function.builtin, support.function.construct, support.constant, support.variable</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ec9878</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Types And Classes</string>
+      <key>scope</key>
+      <string>entity.name.type, entity.name.class, entity.name.struct, entity.name.enum, entity.name.trait, support.type, support.class, meta.type</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#90aec0</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Decorators And Attributes</string>
+      <key>scope</key>
+      <string>meta.decorator, meta.annotation, entity.name.function.decorator, punctuation.definition.annotation, storage.type.annotation</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#e6c08a</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Tags</string>
+      <key>scope</key>
+      <string>entity.name.tag, meta.tag, punctuation.definition.tag</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#dc9e92</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Attributes</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name, meta.tag.attributes</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ffb454</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>CSS Properties</string>
+      <key>scope</key>
+      <string>support.type.property-name.css, meta.property-name.css, variable.css, entity.other.attribute-name.class.css, entity.other.attribute-name.id.css</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#deb074</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Members And Properties</string>
+      <key>scope</key>
+      <string>variable.other.member, variable.other.property, meta.property.object, meta.object-literal.key, support.variable.property</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ec9878</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Parameters</string>
+      <key>scope</key>
+      <string>variable.parameter, meta.parameters, punctuation.definition.parameters</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#d4a8b8</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Language Variables</string>
+      <key>scope</key>
+      <string>variable.language, variable.other.this, variable.language.this</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#dc9e92</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation</string>
+      <key>scope</key>
+      <string>punctuation, punctuation.separator, punctuation.terminator, punctuation.section</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#bfbdb6</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Invalid</string>
+      <key>scope</key>
+      <string>invalid, invalid.illegal, invalid.deprecated</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f49090</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup Headings</string>
+      <key>scope</key>
+      <string>markup.heading, entity.name.section</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#b4bc78</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup Links</string>
+      <key>scope</key>
+      <string>markup.underline.link, markup.underline.link.image, string.other.link, meta.link</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#dc9e92</string>
+        <key>fontStyle</key>
+        <string>underline</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup Raw</string>
+      <key>scope</key>
+      <string>markup.raw, markup.raw.inline, markup.raw.block</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f29668</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/bat/Warm Burnout Light.tmTheme
+++ b/bat/Warm Burnout Light.tmTheme
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Warm Burnout Light</string>
+  <key>uuid</key>
+  <string>warm-burnout-light</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#F5EDE0</string>
+        <key>foreground</key>
+        <string>#3a3630</string>
+        <key>caret</key>
+        <string>#8a6600</string>
+        <key>selection</key>
+        <string>#e5e8e2</string>
+        <key>lineHighlight</key>
+        <string>#e2dace</string>
+        <key>invisibles</key>
+        <string>#8a8070</string>
+        <key>gutterForeground</key>
+        <string>#8a8070</string>
+        <key>gutterBackground</key>
+        <string>#F5EDE0</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Comments</string>
+      <key>scope</key>
+      <string>comment, punctuation.definition.comment</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#544c40</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Strings</string>
+      <key>scope</key>
+      <string>string, punctuation.definition.string, string.quoted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#4d5c1a</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Regular Expressions And Escapes</string>
+      <key>scope</key>
+      <string>string.regexp, constant.character.escape, constant.other.character-class, keyword.operator.quantifier.regexp</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#286a48</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constants And Numbers</string>
+      <key>scope</key>
+      <string>constant, constant.numeric, constant.language, constant.character, variable.other.constant</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#7e4060</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keywords</string>
+      <key>scope</key>
+      <string>keyword, keyword.control, keyword.other, storage, storage.modifier, storage.type</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#924800</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Operators</string>
+      <key>scope</key>
+      <string>keyword.operator, keyword.operator.assignment, keyword.operator.comparison, keyword.operator.logical, keyword.operator.arithmetic</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8f4418</string>
+        <key>fontStyle</key>
+        <string></string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Functions</string>
+      <key>scope</key>
+      <string>entity.name.function, support.function, meta.function-call, variable.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#855700</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Library Functions And Support</string>
+      <key>scope</key>
+      <string>support.function.builtin, support.function.construct, support.constant, support.variable</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#883850</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Types And Classes</string>
+      <key>scope</key>
+      <string>entity.name.type, entity.name.class, entity.name.struct, entity.name.enum, entity.name.trait, support.type, support.class, meta.type</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#285464</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Decorators And Attributes</string>
+      <key>scope</key>
+      <string>meta.decorator, meta.annotation, entity.name.function.decorator, punctuation.definition.annotation, storage.type.annotation</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#7a5a1c</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Tags</string>
+      <key>scope</key>
+      <string>entity.name.tag, meta.tag, punctuation.definition.tag</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8e4632</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Attributes</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name, meta.tag.attributes</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#855700</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>CSS Properties</string>
+      <key>scope</key>
+      <string>support.type.property-name.css, meta.property-name.css, variable.css, entity.other.attribute-name.class.css, entity.other.attribute-name.id.css</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#74501c</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Members And Properties</string>
+      <key>scope</key>
+      <string>variable.other.member, variable.other.property, meta.property.object, meta.object-literal.key, support.variable.property</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#883850</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Parameters</string>
+      <key>scope</key>
+      <string>variable.parameter, meta.parameters, punctuation.definition.parameters</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#7e4060</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Language Variables</string>
+      <key>scope</key>
+      <string>variable.language, variable.other.this, variable.language.this</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8e4632</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation</string>
+      <key>scope</key>
+      <string>punctuation, punctuation.separator, punctuation.terminator, punctuation.section</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#3a3630</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Invalid</string>
+      <key>scope</key>
+      <string>invalid, invalid.illegal, invalid.deprecated</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#b03434</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup Headings</string>
+      <key>scope</key>
+      <string>markup.heading, entity.name.section</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#4d5c1a</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup Links</string>
+      <key>scope</key>
+      <string>markup.underline.link, markup.underline.link.image, string.other.link, meta.link</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8e4632</string>
+        <key>fontStyle</key>
+        <string>underline</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markup Raw</string>
+      <key>scope</key>
+      <string>markup.raw, markup.raw.inline, markup.raw.block</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#8f4418</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/bat/Warm Burnout Light.tmTheme
+++ b/bat/Warm Burnout Light.tmTheme
@@ -177,7 +177,7 @@
       <key>name</key>
       <string>CSS Properties</string>
       <key>scope</key>
-      <string>support.type.property-name.css, meta.property-name.css, variable.css, entity.other.attribute-name.class.css, entity.other.attribute-name.id.css</string>
+      <string>support.type.property-name.css, meta.property-name.css, variable.css</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -201,7 +201,7 @@
       <key>name</key>
       <string>Parameters</string>
       <key>scope</key>
-      <string>variable.parameter, meta.parameters, punctuation.definition.parameters</string>
+      <string>variable.parameter</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>

--- a/site/index.html
+++ b/site/index.html
@@ -423,6 +423,12 @@
             <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
           </a>
 
+          <a href="https://github.com/felipefdl/warm-burnout/tree/main/bat" class="retro-card rounded-md p-4 no-underline block">
+            <p class="text-sm font-bold theme-fg">Bat</p>
+            <p class="text-xs theme-fg-muted mt-1">Syntax pager</p>
+            <span class="inline-block mt-2 text-xs font-bold px-2 py-0.5 rounded" style="background: rgba(184, 82, 46, 0.15); color: var(--theme-accent);">Available</span>
+          </a>
+
           <a href="https://github.com/felipefdl/warm-burnout/tree/main/xcode" class="retro-card rounded-md p-4 no-underline block">
             <p class="text-sm font-bold theme-fg">Xcode</p>
             <p class="text-xs theme-fg-muted mt-1">Editor</p>

--- a/tests/bat.rs
+++ b/tests/bat.rs
@@ -1,26 +1,21 @@
 mod common;
 
 use common::{
-  bat_tmtheme_global_setting, bat_tmtheme_name, bat_tmtheme_scope_font_style, bat_tmtheme_scope_foreground,
-  extract_hex_colors, is_valid_hex,
+  bat_tmtheme_global_setting, bat_tmtheme_name, bat_tmtheme_root, bat_tmtheme_scope_font_style,
+  bat_tmtheme_scope_foreground, extract_hex_colors, is_valid_hex,
 };
 
 const DARK: &str = include_str!("../bat/Warm Burnout Dark.tmTheme");
 const LIGHT: &str = include_str!("../bat/Warm Burnout Light.tmTheme");
 
-fn parse_tmtheme(src: &str) -> plist::Value {
-  let cursor = std::io::Cursor::new(src.as_bytes());
-  plist::from_reader(cursor).expect("invalid tmTheme plist")
-}
-
 #[test]
 fn dark_is_valid_tmtheme_plist() {
-  parse_tmtheme(DARK);
+  bat_tmtheme_root(DARK);
 }
 
 #[test]
 fn light_is_valid_tmtheme_plist() {
-  parse_tmtheme(LIGHT);
+  bat_tmtheme_root(LIGHT);
 }
 
 #[test]
@@ -71,6 +66,7 @@ fn dark_syntax_colors_match_palette() {
     ("keyword", "#ff8f40"),
     ("keyword.operator", "#f29668"),
     ("entity.name.function", "#ffb454"),
+    ("support.function.builtin", "#ec9878"),
     ("entity.name.type", "#90aec0"),
     ("string", "#b4bc78"),
     ("string.regexp", "#96b898"),
@@ -79,6 +75,7 @@ fn dark_syntax_colors_match_palette() {
     ("variable.other.member", "#ec9878"),
     ("comment", "#b4a89c"),
     ("invalid", "#f49090"),
+    ("meta.decorator", "#e6c08a"),
     ("support.type.property-name.css", "#deb074"),
   ] {
     assert_eq!(bat_tmtheme_scope_foreground(DARK, scope), expected, "dark {scope}");
@@ -91,6 +88,7 @@ fn light_syntax_colors_match_palette() {
     ("keyword", "#924800"),
     ("keyword.operator", "#8f4418"),
     ("entity.name.function", "#855700"),
+    ("support.function.builtin", "#883850"),
     ("entity.name.type", "#285464"),
     ("string", "#4d5c1a"),
     ("string.regexp", "#286a48"),
@@ -99,6 +97,7 @@ fn light_syntax_colors_match_palette() {
     ("variable.other.member", "#883850"),
     ("comment", "#544c40"),
     ("invalid", "#b03434"),
+    ("meta.decorator", "#7a5a1c"),
     ("support.type.property-name.css", "#74501c"),
   ] {
     assert_eq!(bat_tmtheme_scope_foreground(LIGHT, scope), expected, "light {scope}");
@@ -116,6 +115,7 @@ fn dark_font_styles_preserve_three_tiers() {
     bat_tmtheme_scope_font_style(DARK, "support.type.property-name.css"),
     "italic"
   );
+  assert_eq!(bat_tmtheme_scope_font_style(DARK, "keyword.operator"), "");
 }
 
 #[test]
@@ -129,6 +129,7 @@ fn light_font_styles_preserve_three_tiers() {
     bat_tmtheme_scope_font_style(LIGHT, "support.type.property-name.css"),
     "italic"
   );
+  assert_eq!(bat_tmtheme_scope_font_style(LIGHT, "keyword.operator"), "");
 }
 
 #[test]

--- a/tests/bat.rs
+++ b/tests/bat.rs
@@ -1,0 +1,142 @@
+mod common;
+
+use common::{
+  bat_tmtheme_global_setting, bat_tmtheme_name, bat_tmtheme_scope_font_style, bat_tmtheme_scope_foreground,
+  extract_hex_colors, is_valid_hex,
+};
+
+const DARK: &str = include_str!("../bat/Warm Burnout Dark.tmTheme");
+const LIGHT: &str = include_str!("../bat/Warm Burnout Light.tmTheme");
+
+fn parse_tmtheme(src: &str) -> plist::Value {
+  let cursor = std::io::Cursor::new(src.as_bytes());
+  plist::from_reader(cursor).expect("invalid tmTheme plist")
+}
+
+#[test]
+fn dark_is_valid_tmtheme_plist() {
+  parse_tmtheme(DARK);
+}
+
+#[test]
+fn light_is_valid_tmtheme_plist() {
+  parse_tmtheme(LIGHT);
+}
+
+#[test]
+fn dark_name_is_warm_burnout_dark() {
+  assert_eq!(bat_tmtheme_name(DARK), "Warm Burnout Dark");
+}
+
+#[test]
+fn light_name_is_warm_burnout_light() {
+  assert_eq!(bat_tmtheme_name(LIGHT), "Warm Burnout Light");
+}
+
+#[test]
+fn dark_all_hex_colors_are_valid() {
+  for (line, hex) in extract_hex_colors(DARK) {
+    assert!(is_valid_hex(hex), "dark line {line}: invalid hex: {hex}");
+  }
+}
+
+#[test]
+fn light_all_hex_colors_are_valid() {
+  for (line, hex) in extract_hex_colors(LIGHT) {
+    assert!(is_valid_hex(hex), "light line {line}: invalid hex: {hex}");
+  }
+}
+
+#[test]
+fn dark_global_colors_match_palette() {
+  assert_eq!(bat_tmtheme_global_setting(DARK, "background"), "#1a1510");
+  assert_eq!(bat_tmtheme_global_setting(DARK, "foreground"), "#bfbdb6");
+  assert_eq!(bat_tmtheme_global_setting(DARK, "caret"), "#f5c56e");
+  assert_eq!(bat_tmtheme_global_setting(DARK, "selection"), "#33393a");
+  assert_eq!(bat_tmtheme_global_setting(DARK, "lineHighlight"), "#222018");
+}
+
+#[test]
+fn light_global_colors_match_palette() {
+  assert_eq!(bat_tmtheme_global_setting(LIGHT, "background"), "#f5ede0");
+  assert_eq!(bat_tmtheme_global_setting(LIGHT, "foreground"), "#3a3630");
+  assert_eq!(bat_tmtheme_global_setting(LIGHT, "caret"), "#8a6600");
+  assert_eq!(bat_tmtheme_global_setting(LIGHT, "selection"), "#e5e8e2");
+  assert_eq!(bat_tmtheme_global_setting(LIGHT, "lineHighlight"), "#e2dace");
+}
+
+#[test]
+fn dark_syntax_colors_match_palette() {
+  for (scope, expected) in [
+    ("keyword", "#ff8f40"),
+    ("keyword.operator", "#f29668"),
+    ("entity.name.function", "#ffb454"),
+    ("entity.name.type", "#90aec0"),
+    ("string", "#b4bc78"),
+    ("string.regexp", "#96b898"),
+    ("constant", "#d4a8b8"),
+    ("entity.name.tag", "#dc9e92"),
+    ("variable.other.member", "#ec9878"),
+    ("comment", "#b4a89c"),
+    ("invalid", "#f49090"),
+    ("support.type.property-name.css", "#deb074"),
+  ] {
+    assert_eq!(bat_tmtheme_scope_foreground(DARK, scope), expected, "dark {scope}");
+  }
+}
+
+#[test]
+fn light_syntax_colors_match_palette() {
+  for (scope, expected) in [
+    ("keyword", "#924800"),
+    ("keyword.operator", "#8f4418"),
+    ("entity.name.function", "#855700"),
+    ("entity.name.type", "#285464"),
+    ("string", "#4d5c1a"),
+    ("string.regexp", "#286a48"),
+    ("constant", "#7e4060"),
+    ("entity.name.tag", "#8e4632"),
+    ("variable.other.member", "#883850"),
+    ("comment", "#544c40"),
+    ("invalid", "#b03434"),
+    ("support.type.property-name.css", "#74501c"),
+  ] {
+    assert_eq!(bat_tmtheme_scope_foreground(LIGHT, scope), expected, "light {scope}");
+  }
+}
+
+#[test]
+fn dark_font_styles_preserve_three_tiers() {
+  assert_eq!(bat_tmtheme_scope_font_style(DARK, "keyword"), "bold");
+  assert_eq!(bat_tmtheme_scope_font_style(DARK, "entity.name.tag"), "bold");
+  assert_eq!(bat_tmtheme_scope_font_style(DARK, "entity.name.type"), "italic");
+  assert_eq!(bat_tmtheme_scope_font_style(DARK, "comment"), "italic");
+  assert_eq!(bat_tmtheme_scope_font_style(DARK, "meta.decorator"), "italic");
+  assert_eq!(
+    bat_tmtheme_scope_font_style(DARK, "support.type.property-name.css"),
+    "italic"
+  );
+}
+
+#[test]
+fn light_font_styles_preserve_three_tiers() {
+  assert_eq!(bat_tmtheme_scope_font_style(LIGHT, "keyword"), "bold");
+  assert_eq!(bat_tmtheme_scope_font_style(LIGHT, "entity.name.tag"), "bold");
+  assert_eq!(bat_tmtheme_scope_font_style(LIGHT, "entity.name.type"), "italic");
+  assert_eq!(bat_tmtheme_scope_font_style(LIGHT, "comment"), "italic");
+  assert_eq!(bat_tmtheme_scope_font_style(LIGHT, "meta.decorator"), "italic");
+  assert_eq!(
+    bat_tmtheme_scope_font_style(LIGHT, "support.type.property-name.css"),
+    "italic"
+  );
+}
+
+#[test]
+fn dark_has_no_pure_black_background() {
+  assert_ne!(bat_tmtheme_global_setting(DARK, "background"), "#000000");
+}
+
+#[test]
+fn light_has_no_pure_white_background() {
+  assert_ne!(bat_tmtheme_global_setting(LIGHT, "background"), "#ffffff");
+}

--- a/tests/brand.rs
+++ b/tests/brand.rs
@@ -15,6 +15,7 @@ const READMES: &[(&str, &str)] = &[
   ("obsidian", include_str!("../obsidian/README.md")),
   ("emacs", include_str!("../emacs/README.md")),
   ("helix", include_str!("../helix/README.md")),
+  ("bat", include_str!("../bat/README.md")),
 ];
 
 #[test]
@@ -63,6 +64,8 @@ fn no_theme_file_uses_patina_as_label() {
     ("emacs/light", include_str!("../emacs/warm-burnout-light-theme.el")),
     ("helix/dark", include_str!("../helix/warm-burnout-dark.toml")),
     ("helix/light", include_str!("../helix/warm-burnout-light.toml")),
+    ("bat/dark", include_str!("../bat/Warm Burnout Dark.tmTheme")),
+    ("bat/light", include_str!("../bat/Warm Burnout Light.tmTheme")),
   ];
   for (name, content) in theme_files {
     for line in content.lines() {

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -1,10 +1,11 @@
 mod common;
 
 use common::{
-  alacritty_color, emacs_palette_color, ghostty_ansi_color, ghostty_color, helix_palette_color, hex_to_lower,
-  home_assistant_color, iterm2_color, jetbrains_attribute, jetbrains_color, nvim_palette_color, obsidian_color,
-  starship_palette_color, tmux_option_value, tmux_style_bg, tmux_style_fg, vscode_color, warp_ansi_color, warp_color,
-  windows_terminal_color, xcode_color, xcode_syntax_color, zed_editor_color, zellij_color,
+  alacritty_color, bat_tmtheme_global_setting, emacs_palette_color, ghostty_ansi_color, ghostty_color,
+  helix_palette_color, hex_to_lower, home_assistant_color, iterm2_color, jetbrains_attribute, jetbrains_color,
+  nvim_palette_color, obsidian_color, starship_palette_color, tmux_option_value, tmux_style_bg, tmux_style_fg,
+  vscode_color, warp_ansi_color, warp_color, windows_terminal_color, xcode_color, xcode_syntax_color, zed_editor_color,
+  zellij_color,
 };
 
 fn zsh_foreground(src: &str) -> Option<String> {
@@ -1076,6 +1077,39 @@ fn light_bright_ansi_warp_matches_ghostty() {
     8,
     "light",
   );
+}
+
+// -- Bat cross-platform consistency --
+
+const BAT_DARK: &str = include_str!("../bat/Warm Burnout Dark.tmTheme");
+const BAT_LIGHT: &str = include_str!("../bat/Warm Burnout Light.tmTheme");
+
+#[test]
+fn dark_background_bat_matches_ghostty() {
+  let bat = bat_tmtheme_global_setting(BAT_DARK, "background");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-dark"), "background");
+  assert_eq!(bat, ghostty, "dark background: bat={bat} ghostty={ghostty}");
+}
+
+#[test]
+fn light_background_bat_matches_ghostty() {
+  let bat = bat_tmtheme_global_setting(BAT_LIGHT, "background");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-light"), "background");
+  assert_eq!(bat, ghostty, "light background: bat={bat} ghostty={ghostty}");
+}
+
+#[test]
+fn dark_foreground_bat_matches_ghostty() {
+  let bat = bat_tmtheme_global_setting(BAT_DARK, "foreground");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-dark"), "foreground");
+  assert_eq!(bat, ghostty, "dark foreground: bat={bat} ghostty={ghostty}");
+}
+
+#[test]
+fn light_foreground_bat_matches_ghostty() {
+  let bat = bat_tmtheme_global_setting(BAT_LIGHT, "foreground");
+  let ghostty = ghostty_color(include_str!("../ghostty/warm-burnout-light"), "foreground");
+  assert_eq!(bat, ghostty, "light foreground: bat={bat} ghostty={ghostty}");
 }
 
 // -- Home Assistant cross-platform consistency --

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -151,7 +151,7 @@ pub fn xcode_syntax_font(src: &str, key: &str) -> String {
     .to_string()
 }
 
-fn bat_tmtheme_root(src: &str) -> plist::Value {
+pub fn bat_tmtheme_root(src: &str) -> plist::Value {
   let cursor = std::io::Cursor::new(src.as_bytes());
   plist::from_reader(cursor).expect("invalid tmTheme plist")
 }
@@ -200,7 +200,12 @@ fn bat_tmtheme_scope_setting(src: &str, scope: &str, key: &str) -> String {
     let Some(dict) = entry.as_dictionary() else {
       continue;
     };
-    let scopes = dict.get("scope").and_then(|v| v.as_string()).unwrap_or_default();
+    let Some(scope_field) = dict.get("scope") else {
+      continue;
+    };
+    let scopes = scope_field
+      .as_string()
+      .unwrap_or_else(|| panic!("tmTheme entry has non-string scope field: {scope_field:?}"));
     let has_scope = scopes.split(',').map(str::trim).any(|candidate| candidate == scope);
     if !has_scope {
       continue;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -151,6 +151,84 @@ pub fn xcode_syntax_font(src: &str, key: &str) -> String {
     .to_string()
 }
 
+fn bat_tmtheme_root(src: &str) -> plist::Value {
+  let cursor = std::io::Cursor::new(src.as_bytes());
+  plist::from_reader(cursor).expect("invalid tmTheme plist")
+}
+
+fn bat_tmtheme_settings_array(src: &str) -> Vec<plist::Value> {
+  bat_tmtheme_root(src)
+    .as_dictionary()
+    .expect("tmTheme root is not a dict")
+    .get("settings")
+    .and_then(|v| v.as_array())
+    .expect("tmTheme missing settings array")
+    .clone()
+}
+
+pub fn bat_tmtheme_name(src: &str) -> String {
+  bat_tmtheme_root(src)
+    .as_dictionary()
+    .expect("tmTheme root is not a dict")
+    .get("name")
+    .and_then(|v| v.as_string())
+    .expect("tmTheme missing name")
+    .to_string()
+}
+
+pub fn bat_tmtheme_global_setting(src: &str, key: &str) -> String {
+  let settings = bat_tmtheme_settings_array(src);
+  let first = settings.first().expect("tmTheme settings array is empty");
+  let settings = first
+    .as_dictionary()
+    .and_then(|dict| dict.get("settings"))
+    .and_then(|v| v.as_dictionary())
+    .expect("tmTheme first settings entry missing settings dict");
+  let value = settings
+    .get(key)
+    .and_then(|v| v.as_string())
+    .unwrap_or_else(|| panic!("tmTheme missing global setting: {key}"));
+  if value.starts_with('#') {
+    hex_to_lower(value)
+  } else {
+    value.to_string()
+  }
+}
+
+fn bat_tmtheme_scope_setting(src: &str, scope: &str, key: &str) -> String {
+  for entry in &bat_tmtheme_settings_array(src) {
+    let Some(dict) = entry.as_dictionary() else {
+      continue;
+    };
+    let scopes = dict.get("scope").and_then(|v| v.as_string()).unwrap_or_default();
+    let has_scope = scopes.split(',').map(str::trim).any(|candidate| candidate == scope);
+    if !has_scope {
+      continue;
+    }
+    let settings = dict
+      .get("settings")
+      .and_then(|v| v.as_dictionary())
+      .unwrap_or_else(|| panic!("tmTheme scope '{scope}' missing settings dict"));
+    let value = settings
+      .get(key)
+      .and_then(|v| v.as_string())
+      .unwrap_or_else(|| panic!("tmTheme scope '{scope}' missing setting: {key}"));
+    if value.starts_with('#') {
+      return hex_to_lower(value);
+    }
+    return value.to_string();
+  }
+  panic!("tmTheme missing scope: {scope}");
+}
+
+pub fn bat_tmtheme_scope_foreground(src: &str, scope: &str) -> String {
+  bat_tmtheme_scope_setting(src, scope, "foreground")
+}
+
+pub fn bat_tmtheme_scope_font_style(src: &str, scope: &str) -> String {
+  bat_tmtheme_scope_setting(src, scope, "fontStyle")
+}
+
 fn rgba_float_to_hex(rgba: &str) -> String {
   let parts: Vec<f64> = rgba.split_whitespace().map(|s| s.parse().unwrap()).collect();
   assert!(parts.len() >= 3, "rgba string must have at least 3 components");


### PR DESCRIPTION
## Summary

Adds Warm Burnout theme support for Bat, with dark and light `.tmTheme` files that Bat can install, cache, and select by name.

## Changes

- Added Bat dark and light `.tmTheme` files
- Added Bat install docs and platform-specific agent notes
- Added Bat release packaging
- Added Bat to the platform table and site grid
- Added Bat validation tests for plist parsing, palette values, font styles, and brand coverage
- Added canonical checks for Bat background and foreground against Ghostty
