### PR TITLE
fix: avoid italics for function names

### DIFF
--- a/vscode/themes/warm-burnout-dark.json
+++ b/vscode/themes/warm-burnout-dark.json
@@ -563,8 +563,7 @@
 				"entity.name.function"
 			],
 			"settings": {
-				"foreground": "#ffb454",
-				"fontStyle": ""
+				"foreground": "#ffb454"
 			}
 		},
 		{
@@ -610,9 +609,15 @@
 			}
 		},
 		{
-			"name": "Entity name",
+			"name": "Type name",
 			"scope": [
-				"entity.name"
+				"entity.name.type",
+				"entity.name.class",
+				"entity.name.struct",
+				"entity.name.enum",
+				"entity.name.interface",
+				"entity.name.union",
+				"entity.name.trait"
 			],
 			"settings": {
 				"fontStyle": "italic",

--- a/vscode/themes/warm-burnout-dark.json
+++ b/vscode/themes/warm-burnout-dark.json
@@ -563,7 +563,8 @@
 				"entity.name.function"
 			],
 			"settings": {
-				"foreground": "#ffb454"
+				"foreground": "#ffb454",
+				"fontStyle": ""
 			}
 		},
 		{

--- a/vscode/themes/warm-burnout-light.json
+++ b/vscode/themes/warm-burnout-light.json
@@ -563,8 +563,7 @@
 				"entity.name.function"
 			],
 			"settings": {
-				"foreground": "#855700",
-				"fontStyle": ""
+				"foreground": "#855700"
 			}
 		},
 		{
@@ -610,9 +609,15 @@
 			}
 		},
 		{
-			"name": "Entity name",
+			"name": "Type name",
 			"scope": [
-				"entity.name"
+				"entity.name.type",
+				"entity.name.class",
+				"entity.name.struct",
+				"entity.name.enum",
+				"entity.name.interface",
+				"entity.name.union",
+				"entity.name.trait"
 			],
 			"settings": {
 				"fontStyle": "italic",

--- a/vscode/themes/warm-burnout-light.json
+++ b/vscode/themes/warm-burnout-light.json
@@ -563,7 +563,8 @@
 				"entity.name.function"
 			],
 			"settings": {
-				"foreground": "#855700"
+				"foreground": "#855700",
+				"fontStyle": ""
 			}
 		},
 		{


### PR DESCRIPTION
When I installed the vscode plugin (v1.7.0), the function names were italicized. This fixes it for me.
