### PR TITLE
Add support for the lualine pplugin in the neovim theme

### DIFF
--- a/nvim/AGENTS.md
+++ b/nvim/AGENTS.md
@@ -21,9 +21,13 @@ nvim/
   lua/
     warm-burnout/
       init.lua                -- setup(), load(variant)
-      palette.lua             -- Dark + light palette tables
+      palette.lua             -- Dark + light palette tables + resolve()
       highlights.lua          -- All highlight group definitions
       terminal.lua            -- Terminal ANSI colors (16 colors)
+    lualine/
+      themes/
+        warm-burnout-dark.lua  -- Lualine dark theme
+        warm-burnout-light.lua -- Lualine light theme
   README.md                   -- Install instructions
   AGENTS.md                   -- This file
 ```
@@ -57,9 +61,10 @@ Since the repo is a monorepo (not a pure Neovim plugin), users add the `nvim/` s
 
 ## Adding Plugin Support
 
-1. Add highlight groups to `highlights.lua` in the appropriate section.
-2. Use palette semantic names, not raw hex values.
-3. Follow existing patterns for foreground/background assignment.
+1. Most plugins: add highlight groups to `highlights.lua` in the appropriate section.
+2. Lualine is special: it loads theme tables from `lua/lualine/themes/`, not highlight groups. Theme files must call `palette.resolve(...)` so 8-digit alpha hex values are blended (same path as `load()`).
+3. Use palette semantic names, not raw hex values.
+4. Follow existing patterns for foreground/background assignment.
 
 ## Color Rules
 

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -50,6 +50,7 @@ require('warm-burnout').load('light')
 - Neo-tree
 - Barbar
 - Mini.statusline
+- Lualine
 - Which-key
 - Trouble
 - Flash
@@ -58,6 +59,14 @@ require('warm-burnout').load('light')
 - Indent-blankline
 - Lazy
 - Notify
+
+### Lualine
+
+```lua
+require("lualine").setup({
+  options = { theme = "warm-burnout-dark" }, -- or "warm-burnout-light"
+})
+```
 
 ## The Palette
 

--- a/nvim/lua/lualine/themes/warm-burnout-dark.lua
+++ b/nvim/lua/lualine/themes/warm-burnout-dark.lua
@@ -1,0 +1,37 @@
+local palette = require('warm-burnout.palette').dark
+local theme
+
+theme = {
+    normal = {
+        a = { bg = palette.accent, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    insert = {
+        a = { bg = palette.string, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    visual = {
+        a = { bg = palette.func, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    replace = {
+        a = { bg = palette.type, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    command = {
+        a = { bg = palette.constant, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    inactive = {
+        a = { bg = palette.bg, fg = palette.comment, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+}
+
+return theme

--- a/nvim/lua/lualine/themes/warm-burnout-dark.lua
+++ b/nvim/lua/lualine/themes/warm-burnout-dark.lua
@@ -8,22 +8,22 @@ theme = {
         c = { bg = palette.bg, fg = palette.fg },
     },
     insert = {
-        a = { bg = palette.string, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.added, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },
     visual = {
-        a = { bg = palette.func, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.keyword, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },
     replace = {
-        a = { bg = palette.type, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.error, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },
     command = {
-        a = { bg = palette.constant, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.cursor, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },

--- a/nvim/lua/lualine/themes/warm-burnout-dark.lua
+++ b/nvim/lua/lualine/themes/warm-burnout-dark.lua
@@ -1,37 +1,39 @@
-local palette = require('warm-burnout.palette').dark
-local theme
+local p = require("warm-burnout.palette").resolve(require("warm-burnout.palette").dark)
 
-theme = {
-    normal = {
-        a = { bg = palette.accent, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    insert = {
-        a = { bg = palette.added, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    visual = {
-        a = { bg = palette.keyword, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    replace = {
-        a = { bg = palette.error, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    command = {
-        a = { bg = palette.cursor, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    inactive = {
-        a = { bg = palette.bg, fg = palette.comment, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
+return {
+  normal = {
+    a = { bg = p.accent, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  insert = {
+    a = { bg = p.added, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  visual = {
+    a = { bg = p.keyword, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  replace = {
+    a = { bg = p.error, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  command = {
+    a = { bg = p.cursor, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  terminal = {
+    a = { bg = p.info, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  inactive = {
+    a = { bg = p.bg, fg = p.comment, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
 }
-
-return theme

--- a/nvim/lua/lualine/themes/warm-burnout-light.lua
+++ b/nvim/lua/lualine/themes/warm-burnout-light.lua
@@ -8,22 +8,22 @@ theme = {
         c = { bg = palette.bg, fg = palette.fg },
     },
     insert = {
-        a = { bg = palette.string, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.added, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },
     visual = {
-        a = { bg = palette.func, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.keyword, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },
     replace = {
-        a = { bg = palette.type, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.error, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },
     command = {
-        a = { bg = palette.constant, fg = palette.bg, gui = 'bold' },
+        a = { bg = palette.cursor, fg = palette.bg, gui = 'bold' },
         b = { bg = palette.bg_highlight, fg = palette.fg },
         c = { bg = palette.bg, fg = palette.fg },
     },

--- a/nvim/lua/lualine/themes/warm-burnout-light.lua
+++ b/nvim/lua/lualine/themes/warm-burnout-light.lua
@@ -1,0 +1,37 @@
+local palette = require('warm-burnout.palette').light
+local theme
+
+theme = {
+    normal = {
+        a = { bg = palette.accent, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    insert = {
+        a = { bg = palette.string, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    visual = {
+        a = { bg = palette.func, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    replace = {
+        a = { bg = palette.type, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    command = {
+        a = { bg = palette.constant, fg = palette.bg, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+    inactive = {
+        a = { bg = palette.bg, fg = palette.comment, gui = 'bold' },
+        b = { bg = palette.bg_highlight, fg = palette.fg },
+        c = { bg = palette.bg, fg = palette.fg },
+    },
+}
+
+return theme

--- a/nvim/lua/lualine/themes/warm-burnout-light.lua
+++ b/nvim/lua/lualine/themes/warm-burnout-light.lua
@@ -1,37 +1,39 @@
-local palette = require('warm-burnout.palette').light
-local theme
+local p = require("warm-burnout.palette").resolve(require("warm-burnout.palette").light)
 
-theme = {
-    normal = {
-        a = { bg = palette.accent, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    insert = {
-        a = { bg = palette.added, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    visual = {
-        a = { bg = palette.keyword, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    replace = {
-        a = { bg = palette.error, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    command = {
-        a = { bg = palette.cursor, fg = palette.bg, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
-    inactive = {
-        a = { bg = palette.bg, fg = palette.comment, gui = 'bold' },
-        b = { bg = palette.bg_highlight, fg = palette.fg },
-        c = { bg = palette.bg, fg = palette.fg },
-    },
+return {
+  normal = {
+    a = { bg = p.accent, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  insert = {
+    a = { bg = p.added, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  visual = {
+    a = { bg = p.keyword, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  replace = {
+    a = { bg = p.error, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  command = {
+    a = { bg = p.cursor, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  terminal = {
+    a = { bg = p.info, fg = p.bg, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
+  inactive = {
+    a = { bg = p.bg, fg = p.comment, gui = "bold" },
+    b = { bg = p.bg_highlight, fg = p.fg },
+    c = { bg = p.bg, fg = p.fg },
+  },
 }
-
-return theme

--- a/nvim/lua/warm-burnout/init.lua
+++ b/nvim/lua/warm-burnout/init.lua
@@ -1,40 +1,5 @@
 local M = {}
 
--- Neovim's nvim_set_hl does not support 8-digit alpha hex (#rrggbbaa).
--- Pre-blend any alpha hex value against the editor background to produce
--- an opaque 6-digit hex that Neovim can use.
-local function hex_to_rgb(hex)
-  hex = hex:gsub("^#", "")
-  return tonumber(hex:sub(1, 2), 16), tonumber(hex:sub(3, 4), 16), tonumber(hex:sub(5, 6), 16)
-end
-
-local function blend_alpha(hex, bg_hex)
-  local raw = hex:gsub("^#", "")
-  if #raw ~= 8 then
-    return hex
-  end
-  local r, g, b = hex_to_rgb(raw)
-  local a = tonumber(raw:sub(7, 8), 16) / 255
-  local br, bg_c, bb = hex_to_rgb(bg_hex)
-  local nr = math.floor(br + (r - br) * a + 0.5)
-  local ng = math.floor(bg_c + (g - bg_c) * a + 0.5)
-  local nb = math.floor(bb + (b - bb) * a + 0.5)
-  return string.format("#%02x%02x%02x", nr, ng, nb)
-end
-
-local function resolve_palette(p)
-  local bg = p.bg
-  local resolved = {}
-  for k, v in pairs(p) do
-    if type(v) == "string" and v:match("^#%x%x%x%x%x%x%x%x$") then
-      resolved[k] = blend_alpha(v, bg)
-    else
-      resolved[k] = v
-    end
-  end
-  return resolved
-end
-
 function M.load(variant)
   variant = variant or "dark"
 
@@ -50,7 +15,7 @@ function M.load(variant)
   local highlights = require("warm-burnout.highlights")
   local terminal = require("warm-burnout.terminal")
 
-  local p = resolve_palette(palette[variant])
+  local p = palette.resolve(palette[variant])
   local groups = highlights.get(p)
 
   for group, opts in pairs(groups) do

--- a/nvim/lua/warm-burnout/palette.lua
+++ b/nvim/lua/warm-burnout/palette.lua
@@ -134,4 +134,42 @@ M.light = {
   none = "NONE",
 }
 
+-- Neovim's nvim_set_hl does not support 8-digit alpha hex (#rrggbbaa).
+-- Pre-blend any alpha hex value against the editor background to produce
+-- an opaque 6-digit hex that Neovim can use.
+local function hex_to_rgb(hex)
+  hex = hex:gsub("^#", "")
+  return tonumber(hex:sub(1, 2), 16), tonumber(hex:sub(3, 4), 16), tonumber(hex:sub(5, 6), 16)
+end
+
+local function blend_alpha(hex, bg_hex)
+  local raw = hex:gsub("^#", "")
+  if #raw ~= 8 then
+    return hex
+  end
+  local r, g, b = hex_to_rgb(raw)
+  local a = tonumber(raw:sub(7, 8), 16) / 255
+  local br, bg_c, bb = hex_to_rgb(bg_hex)
+  local nr = math.floor(br + (r - br) * a + 0.5)
+  local ng = math.floor(bg_c + (g - bg_c) * a + 0.5)
+  local nb = math.floor(bb + (b - bb) * a + 0.5)
+  return string.format("#%02x%02x%02x", nr, ng, nb)
+end
+
+---Return a copy of palette `p` with 8-digit alpha hex values blended against `p.bg`.
+---@param p table
+---@return table
+function M.resolve(p)
+  local bg = p.bg
+  local resolved = {}
+  for k, v in pairs(p) do
+    if type(v) == "string" and v:match("^#%x%x%x%x%x%x%x%x$") then
+      resolved[k] = blend_alpha(v, bg)
+    else
+      resolved[k] = v
+    end
+  end
+  return resolved
+end
+
 return M

--- a/nvim/stylua.toml
+++ b/nvim/stylua.toml
@@ -1,0 +1,7 @@
+column_width = 200
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferSingle"
+call_parentheses = "Always"
+# collapse_simple_statement = "Always"

--- a/nvim/stylua.toml
+++ b/nvim/stylua.toml
@@ -1,7 +1,0 @@
-column_width = 200
-line_endings = "Unix"
-indent_type = "Spaces"
-indent_width = 4
-quote_style = "AutoPreferSingle"
-call_parentheses = "Always"
-# collapse_simple_statement = "Always"

--- a/tests/nvim.rs
+++ b/tests/nvim.rs
@@ -877,22 +877,93 @@ fn light_selection_matches_vscode() {
   );
 }
 
-// -- Init resolves alpha hex colors --
+// -- Palette resolves alpha hex colors --
 
 #[test]
-fn init_has_alpha_blend_function() {
+fn palette_has_alpha_blend_function() {
   assert!(
-    INIT.contains("blend_alpha"),
-    "init.lua should have alpha blending function"
+    PALETTE.contains("blend_alpha"),
+    "palette.lua should have alpha blending function"
+  );
+}
+
+#[test]
+fn palette_exports_resolve() {
+  assert!(
+    PALETTE.contains("function M.resolve"),
+    "palette.lua should export resolve for 8-digit alpha blending"
   );
 }
 
 #[test]
 fn init_resolves_palette_before_applying() {
   assert!(
-    INIT.contains("resolve_palette"),
+    INIT.contains("palette.resolve"),
     "init.lua should resolve palette (blend alpha hex) before applying highlights"
   );
+}
+
+// -- Lualine themes --
+
+const LUALINE_DARK: &str = include_str!("../nvim/lua/lualine/themes/warm-burnout-dark.lua");
+const LUALINE_LIGHT: &str = include_str!("../nvim/lua/lualine/themes/warm-burnout-light.lua");
+
+#[test]
+fn lualine_themes_resolve_palette() {
+  for (name, body) in [("dark", LUALINE_DARK), ("light", LUALINE_LIGHT)] {
+    assert!(
+      body.contains(".resolve("),
+      "lualine {name} theme must call palette.resolve so alpha hex is blended"
+    );
+  }
+}
+
+#[test]
+fn lualine_themes_define_modes() {
+  for mode in [
+    "normal", "insert", "visual", "replace", "command", "terminal", "inactive",
+  ] {
+    for (name, body) in [("dark", LUALINE_DARK), ("light", LUALINE_LIGHT)] {
+      assert!(
+        body.contains(&format!("{mode} =")),
+        "lualine {name} theme missing mode: {mode}"
+      );
+    }
+  }
+}
+
+#[test]
+fn lualine_themes_use_semantic_palette_keys() {
+  for key in [
+    "accent",
+    "added",
+    "keyword",
+    "error",
+    "cursor",
+    "info",
+    "bg_highlight",
+    "bg",
+    "fg",
+    "comment",
+  ] {
+    for (name, body) in [("dark", LUALINE_DARK), ("light", LUALINE_LIGHT)] {
+      assert!(
+        body.contains(&format!("p.{key}")),
+        "lualine {name} theme should use palette key p.{key}"
+      );
+    }
+  }
+}
+
+#[test]
+fn lualine_themes_have_no_raw_hex() {
+  for (name, body) in [("dark", LUALINE_DARK), ("light", LUALINE_LIGHT)] {
+    let hex = extract_hex_colors(body);
+    assert!(
+      hex.is_empty(),
+      "lualine {name} theme must not hardcode hex; found: {hex:?}"
+    );
+  }
 }
 
 // -- Headless Neovim load tests --


### PR DESCRIPTION
Resolves #23 

In this pr i've added the lualine neovim plugin theme for this colorscheme, you'll find the two files that define the theme:
- nvim/lua/lualine/themes/warm-burnout-dark.lua for the dark theme
- nvim/lua/lualine/themes/warm-burnout-light.lua for the light theme

I've also added the stylua.toml, a file used by the lua formatter to format the code

As for the colors, i've followed the ones defined for the mini statusline